### PR TITLE
新增 Spotify Connect 模块

### DIFF
--- a/ChillPatcher.Module.Spotify/ChillPatcher.Module.Spotify.csproj
+++ b/ChillPatcher.Module.Spotify/ChillPatcher.Module.Spotify.csproj
@@ -1,0 +1,78 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <AssemblyName>ChillPatcher.Module.Spotify</AssemblyName>
+    <OutputPath>bin\</OutputPath>
+    <RootNamespace>ChillPatcher.Module.Spotify</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SteamLibraryRoot Condition="'$(SteamLibraryRoot)' == ''">$(CHILL_STEAM_LIBRARY)</SteamLibraryRoot>
+    <SteamLibraryRoot Condition="'$(SteamLibraryRoot)' == ''">F:\SteamLibrary</SteamLibraryRoot>
+    <GamePath>$(SteamLibraryRoot)\steamapps\common\wallpaper_engine\projects\myprojects\chill_with_you\Chill With You_Data\Managed</GamePath>
+    <BepInExCorePath>$(SteamLibraryRoot)\steamapps\common\wallpaper_engine\projects\myprojects\chill_with_you\BepInEx\core</BepInExCorePath>
+  </PropertyGroup>
+
+  <!-- 引用 SDK -->
+  <ItemGroup>
+    <ProjectReference Include="..\ChillPatcher.SDK\ChillPatcher.SDK.csproj">
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+
+  <!-- NuGet Packages -->
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <!-- Unity Engine -->
+  <ItemGroup>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(GamePath)\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AudioModule">
+      <HintPath>$(GamePath)\UnityEngine.AudioModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ImageConversionModule">
+      <HintPath>$(GamePath)\UnityEngine.ImageConversionModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.Networking">
+      <HintPath>$(GamePath)\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestTextureModule">
+      <HintPath>$(GamePath)\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>$(GamePath)\UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>$(GamePath)\UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
+  <!-- BepInEx -->
+  <ItemGroup>
+    <Reference Include="BepInEx">
+      <HintPath>$(BepInExCorePath)\BepInEx.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/ChillPatcher.Module.Spotify/OAuthManager.cs
+++ b/ChillPatcher.Module.Spotify/OAuthManager.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BepInEx.Logging;
+using Microsoft.Win32;
+using Newtonsoft.Json;
+
+namespace ChillPatcher.Module.Spotify
+{
+    /// <summary>
+    /// Spotify OAuth 2.0 PKCE 认证管理器。
+    /// 使用 fullstop:// 自定义 URI 协议接收回调，与 sfo 项目保持一致。
+    /// </summary>
+    public class OAuthManager : IDisposable
+    {
+        private const string AuthorizeUrl = "https://accounts.spotify.com/authorize";
+        private const string TokenUrl = "https://accounts.spotify.com/api/token";
+        private const string ProtocolScheme = "fullstop";
+        private const string RedirectUri = "fullstop://callback";
+
+        private static readonly string[] Scopes = new[]
+        {
+            "user-read-private",
+            "user-read-playback-state",
+            "user-modify-playback-state",
+            "user-read-currently-playing",
+            "playlist-read-private",
+            "playlist-read-collaborative",
+            "user-library-read",
+            "user-library-modify"
+        };
+
+        private readonly string _clientId;
+        private readonly string _dataPath;
+        private readonly ManualLogSource _logger;
+        private readonly HttpClient _httpClient;
+        private readonly string _callbackFilePath;
+        private readonly string _handlerScriptPath;
+
+        private string _codeVerifier;
+        private string _codeChallenge;
+        private string _state;
+        private CancellationTokenSource _cts;
+
+        public event Action<SpotifyTokenResponse> OnTokenReceived;
+        public event Action<string> OnLoginFailed;
+        public event Action<string> OnStatusChanged;
+
+        public OAuthManager(string clientId, string dataPath, ManualLogSource logger)
+        {
+            _clientId = clientId;
+            _dataPath = dataPath;
+            _logger = logger;
+            _httpClient = new HttpClient();
+
+            _callbackFilePath = Path.Combine(Path.GetTempPath(), "fullstop_callback.txt");
+            _handlerScriptPath = Path.Combine(dataPath, "fullstop_handler.ps1");
+
+            EnsureProtocolRegistered();
+        }
+
+        // =====================================================================
+        // 自定义 URI 协议注册
+        // =====================================================================
+
+        private void EnsureProtocolRegistered()
+        {
+            try
+            {
+                // 创建 PowerShell 处理脚本
+                Directory.CreateDirectory(_dataPath);
+                var scriptContent = $"[IO.File]::WriteAllText(\"{_callbackFilePath.Replace("\\", "\\\\")}\", $args[0])";
+                File.WriteAllText(_handlerScriptPath, scriptContent, Encoding.UTF8);
+                _logger.LogInfo($"Protocol handler script created: {_handlerScriptPath}");
+
+                // 注册 fullstop:// 协议到 Windows 注册表
+                using (var key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\{ProtocolScheme}"))
+                {
+                    key.SetValue("", $"URL:{ProtocolScheme} Protocol");
+                    key.SetValue("URL Protocol", "");
+
+                    using (var commandKey = key.CreateSubKey(@"shell\open\command"))
+                    {
+                        var command = $"powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File \"{_handlerScriptPath}\" \"%1\"";
+                        commandKey.SetValue("", command);
+                    }
+                }
+
+                _logger.LogInfo($"Registered '{ProtocolScheme}://' protocol handler");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to register protocol handler: {ex.Message}");
+            }
+        }
+
+        // =====================================================================
+        // OAuth 登录流程
+        // =====================================================================
+
+        /// <summary>
+        /// 启动 OAuth 登录流程：生成 PKCE、打开浏览器、等待回调文件。
+        /// </summary>
+        public async Task StartLoginAsync(CancellationToken externalToken = default)
+        {
+            _cts?.Cancel();
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
+
+            // 清理旧的回调文件
+            CleanupCallbackFile();
+
+            // 生成 PKCE
+            (_codeVerifier, _codeChallenge) = GeneratePKCE();
+            _state = GenerateRandomString(16);
+
+            // 构建授权 URL
+            var scope = string.Join(" ", Scopes);
+            var authUrl = $"{AuthorizeUrl}" +
+                $"?client_id={Uri.EscapeDataString(_clientId)}" +
+                $"&response_type=code" +
+                $"&redirect_uri={Uri.EscapeDataString(RedirectUri)}" +
+                $"&scope={Uri.EscapeDataString(scope)}" +
+                $"&code_challenge={_codeChallenge}" +
+                $"&code_challenge_method=S256" +
+                $"&state={_state}";
+
+            // 打开浏览器
+            OnStatusChanged?.Invoke("正在打开浏览器...");
+            try
+            {
+                System.Diagnostics.Process.Start(authUrl);
+                _logger.LogInfo("Opened browser for Spotify authorization");
+                OnStatusChanged?.Invoke("等待浏览器授权...");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to open browser: {ex.Message}");
+                OnLoginFailed?.Invoke("无法打开浏览器，请手动访问授权页面");
+                return;
+            }
+
+            // 轮询回调文件（5 分钟超时）
+            try
+            {
+                var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+                var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, timeoutCts.Token);
+                await PollForCallbackFileAsync(linkedCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogWarning("OAuth flow timed out or was cancelled");
+                OnLoginFailed?.Invoke("登录超时或已取消");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"OAuth error: {ex.Message}");
+                OnLoginFailed?.Invoke($"登录失败: {ex.Message}");
+            }
+            finally
+            {
+                CleanupCallbackFile();
+            }
+        }
+
+        /// <summary>
+        /// 轮询临时文件，等待协议处理器写入回调 URL。
+        /// </summary>
+        private async Task PollForCallbackFileAsync(CancellationToken token)
+        {
+            _logger.LogInfo($"Polling for callback file: {_callbackFilePath}");
+
+            while (!token.IsCancellationRequested)
+            {
+                if (File.Exists(_callbackFilePath))
+                {
+                    // 短暂等待确保文件写入完成
+                    await Task.Delay(200, token);
+
+                    string callbackUrl;
+                    try
+                    {
+                        callbackUrl = File.ReadAllText(_callbackFilePath).Trim();
+                    }
+                    catch (IOException)
+                    {
+                        // 文件可能还在被写入，等一下重试
+                        await Task.Delay(500, token);
+                        continue;
+                    }
+
+                    _logger.LogInfo($"OAuth callback received: {callbackUrl}");
+                    CleanupCallbackFile();
+
+                    ProcessCallbackUrl(callbackUrl);
+                    return;
+                }
+
+                await Task.Delay(500, token);
+            }
+        }
+
+        private async void ProcessCallbackUrl(string callbackUrl)
+        {
+            OnStatusChanged?.Invoke("收到授权回调，正在验证...");
+
+            // 解析 URL 参数: fullstop://callback?code=xxx&state=yyy
+            var queryParams = ParseQueryString(callbackUrl);
+
+            var error = GetParam(queryParams, "error");
+            if (!string.IsNullOrEmpty(error))
+            {
+                OnLoginFailed?.Invoke($"用户拒绝授权: {error}");
+                return;
+            }
+
+            var callbackState = GetParam(queryParams, "state");
+            if (callbackState != _state)
+            {
+                _logger.LogWarning($"State mismatch: expected={_state}, got={callbackState}");
+                OnLoginFailed?.Invoke("State 校验失败，请重试");
+                return;
+            }
+
+            var code = GetParam(queryParams, "code");
+            if (string.IsNullOrEmpty(code))
+            {
+                OnLoginFailed?.Invoke("未收到授权码");
+                return;
+            }
+
+            OnStatusChanged?.Invoke("正在交换 Token...");
+            await ExchangeCodeAsync(code);
+        }
+
+        private async Task ExchangeCodeAsync(string code)
+        {
+            var content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "authorization_code",
+                ["code"] = code,
+                ["redirect_uri"] = RedirectUri,
+                ["client_id"] = _clientId,
+                ["code_verifier"] = _codeVerifier
+            });
+
+            try
+            {
+                var response = await _httpClient.PostAsync(TokenUrl, content);
+                var json = await response.Content.ReadAsStringAsync();
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError($"Token exchange failed ({response.StatusCode}): {json}");
+                    OnLoginFailed?.Invoke("Token 交换失败");
+                    return;
+                }
+
+                var tokenResponse = JsonConvert.DeserializeObject<SpotifyTokenResponse>(json);
+                _logger.LogInfo("Successfully obtained Spotify tokens");
+                OnTokenReceived?.Invoke(tokenResponse);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Token exchange error: {ex.Message}");
+                OnLoginFailed?.Invoke($"Token 交换异常: {ex.Message}");
+            }
+        }
+
+        // =====================================================================
+        // 辅助方法
+        // =====================================================================
+
+        public void Cancel()
+        {
+            _cts?.Cancel();
+            CleanupCallbackFile();
+        }
+
+        private void CleanupCallbackFile()
+        {
+            try
+            {
+                if (File.Exists(_callbackFilePath))
+                    File.Delete(_callbackFilePath);
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// 手动解析 URL 中的查询参数（避免依赖 System.Web）。
+        /// 支持 fullstop://callback?code=xxx&amp;state=yyy 格式。
+        /// </summary>
+        private static Dictionary<string, string> ParseQueryString(string url)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var queryStart = url.IndexOf('?');
+            if (queryStart < 0) return result;
+
+            var query = url.Substring(queryStart + 1);
+            foreach (var pair in query.Split('&'))
+            {
+                var parts = pair.Split(new[] { '=' }, 2);
+                if (parts.Length == 2)
+                    result[Uri.UnescapeDataString(parts[0])] = Uri.UnescapeDataString(parts[1]);
+                else if (parts.Length == 1)
+                    result[Uri.UnescapeDataString(parts[0])] = "";
+            }
+
+            return result;
+        }
+
+        private static string GetParam(Dictionary<string, string> dict, string key)
+        {
+            return dict.TryGetValue(key, out var val) ? val : null;
+        }
+
+        // =====================================================================
+        // PKCE
+        // =====================================================================
+
+        private static (string verifier, string challenge) GeneratePKCE()
+        {
+            var bytes = new byte[32];
+            using (var rng = RandomNumberGenerator.Create())
+                rng.GetBytes(bytes);
+            var verifier = Base64UrlEncode(bytes);
+
+            using (var sha256 = SHA256.Create())
+            {
+                var challengeBytes = sha256.ComputeHash(Encoding.ASCII.GetBytes(verifier));
+                var challenge = Base64UrlEncode(challengeBytes);
+                return (verifier, challenge);
+            }
+        }
+
+        private static string GenerateRandomString(int byteCount)
+        {
+            var bytes = new byte[byteCount];
+            using (var rng = RandomNumberGenerator.Create())
+                rng.GetBytes(bytes);
+            return Base64UrlEncode(bytes);
+        }
+
+        private static string Base64UrlEncode(byte[] bytes)
+        {
+            return Convert.ToBase64String(bytes)
+                .Replace("+", "-")
+                .Replace("/", "_")
+                .TrimEnd('=');
+        }
+
+        public void Dispose()
+        {
+            Cancel();
+            _httpClient?.Dispose();
+            _cts?.Dispose();
+        }
+    }
+}

--- a/ChillPatcher.Module.Spotify/SilentPcmReader.cs
+++ b/ChillPatcher.Module.Spotify/SilentPcmReader.cs
@@ -1,0 +1,55 @@
+using System;
+using ChillPatcher.SDK.Interfaces;
+using ChillPatcher.SDK.Models;
+
+namespace ChillPatcher.Module.Spotify
+{
+    /// <summary>
+    /// Spotify Connect 模式下，音频由 Spotify 客户端播放，游戏端输出静音。
+    /// duration 应与实际曲目时长一致，以便游戏 UI 显示正确的进度条。
+    /// </summary>
+    public class SilentPcmReader : IPcmStreamReader
+    {
+        private readonly ulong _totalFrames;
+        private ulong _currentFrame;
+
+        public SilentPcmReader(float durationSeconds = 120f)
+        {
+            _totalFrames = (ulong)(44100 * durationSeconds);
+        }
+
+        public PcmStreamInfo Info => new PcmStreamInfo
+        {
+            SampleRate = 44100,
+            Channels = 2,
+            TotalFrames = _totalFrames
+        };
+
+        public bool IsReady => true;
+        public ulong CurrentFrame => _currentFrame;
+        public bool IsEndOfStream => _currentFrame >= _totalFrames;
+        public bool CanSeek => true;
+        public double CacheProgress => 100.0;
+        public bool IsCacheComplete => true;
+        public bool HasPendingSeek => false;
+        public long PendingSeekFrame => -1;
+
+        public long ReadFrames(float[] buffer, int framesToRead)
+        {
+            ulong remaining = _totalFrames - _currentFrame;
+            int actual = (int)Math.Min((ulong)framesToRead, remaining);
+            Array.Clear(buffer, 0, actual * 2);
+            _currentFrame += (ulong)actual;
+            return actual;
+        }
+
+        public bool Seek(ulong frameIndex)
+        {
+            _currentFrame = Math.Min(frameIndex, _totalFrames);
+            return true;
+        }
+
+        public void CancelPendingSeek() { }
+        public void Dispose() { }
+    }
+}

--- a/ChillPatcher.Module.Spotify/SpotifyBridge.cs
+++ b/ChillPatcher.Module.Spotify/SpotifyBridge.cs
@@ -1,0 +1,496 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using BepInEx.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ChillPatcher.Module.Spotify
+{
+    /// <summary>
+    /// Spotify Web API 客户端，封装所有 HTTP 调用。
+    /// 支持 token 自动刷新（401 时重试一次）。
+    /// </summary>
+    public class SpotifyBridge : IDisposable
+    {
+        private const string ApiBase = "https://api.spotify.com/v1";
+        private const string TokenUrl = "https://accounts.spotify.com/api/token";
+
+        private readonly HttpClient _httpClient;
+        private readonly string _clientId;
+        private readonly string _dataPath;
+        private readonly ManualLogSource _logger;
+
+        private SpotifySession _session;
+
+        public bool IsLoggedIn => _session != null && _session.IsValid;
+        public SpotifySession Session => _session;
+
+        public SpotifyBridge(string clientId, string dataPath, ManualLogSource logger)
+        {
+            _clientId = clientId;
+            _dataPath = dataPath;
+            _logger = logger;
+
+            var handler = new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            };
+            _httpClient = new HttpClient(handler);
+            _httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+        }
+
+        // =====================================================================
+        // Session 管理
+        // =====================================================================
+
+        public void LoadSession()
+        {
+            var path = GetSessionPath();
+            if (!File.Exists(path)) return;
+
+            try
+            {
+                var json = File.ReadAllText(path);
+                _session = JsonConvert.DeserializeObject<SpotifySession>(json);
+                _logger.LogInfo($"Loaded Spotify session for {_session?.DisplayName ?? "unknown"}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to load session: {ex.Message}");
+                _session = null;
+            }
+        }
+
+        public void SaveSession()
+        {
+            if (_session == null) return;
+            try
+            {
+                Directory.CreateDirectory(_dataPath);
+                File.WriteAllText(GetSessionPath(), JsonConvert.SerializeObject(_session, Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to save session: {ex.Message}");
+            }
+        }
+
+        public void ClearSession()
+        {
+            _session = null;
+            var path = GetSessionPath();
+            if (File.Exists(path))
+            {
+                try { File.Delete(path); } catch { }
+            }
+        }
+
+        public void SetTokens(SpotifyTokenResponse tokenResponse)
+        {
+            if (_session == null) _session = new SpotifySession();
+            _session.AccessToken = tokenResponse.AccessToken;
+            if (!string.IsNullOrEmpty(tokenResponse.RefreshToken))
+                _session.RefreshToken = tokenResponse.RefreshToken;
+            _session.ExpiresAt = DateTime.UtcNow.AddSeconds(tokenResponse.ExpiresIn);
+            SaveSession();
+        }
+
+        private string GetSessionPath() => Path.Combine(_dataPath, "spotify_session.json");
+
+        // =====================================================================
+        // Token 刷新
+        // =====================================================================
+
+        public async Task<bool> RefreshTokenAsync()
+        {
+            if (_session == null || string.IsNullOrEmpty(_session.RefreshToken))
+                return false;
+
+            try
+            {
+                var content = new FormUrlEncodedContent(new Dictionary<string, string>
+                {
+                    ["grant_type"] = "refresh_token",
+                    ["refresh_token"] = _session.RefreshToken,
+                    ["client_id"] = _clientId
+                });
+
+                var response = await _httpClient.PostAsync(TokenUrl, content);
+                var json = await response.Content.ReadAsStringAsync();
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError($"Token refresh failed ({response.StatusCode}): {json}");
+                    return false;
+                }
+
+                var tokenResponse = JsonConvert.DeserializeObject<SpotifyTokenResponse>(json);
+                SetTokens(tokenResponse);
+                _logger.LogInfo("Spotify token refreshed successfully");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Token refresh error: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 确保 token 有效，过期则自动刷新。
+        /// </summary>
+        public async Task<bool> EnsureTokenValidAsync()
+        {
+            if (_session == null || !_session.IsValid) return false;
+            if (!_session.IsExpired) return true;
+            return await RefreshTokenAsync();
+        }
+
+        // =====================================================================
+        // User
+        // =====================================================================
+
+        public async Task<SpotifyUser> GetCurrentUserAsync()
+        {
+            return await GetAsync<SpotifyUser>("/me");
+        }
+
+        // =====================================================================
+        // Playlists
+        // =====================================================================
+
+        /// <summary>
+        /// 获取用户所有歌单（自动分页）。
+        /// </summary>
+        public async Task<List<SpotifyPlaylist>> GetUserPlaylistsAsync()
+        {
+            _logger.LogInfo("Fetching user playlists...");
+            var all = new List<SpotifyPlaylist>();
+            int offset = 0;
+            const int limit = 50;
+
+            while (true)
+            {
+                var page = await GetAsync<SpotifyPaged<SpotifyPlaylist>>($"/me/playlists?limit={limit}&offset={offset}");
+                if (page?.Items == null || page.Items.Count == 0) break;
+
+                all.AddRange(page.Items);
+                _logger.LogInfo($"  Fetched {all.Count}/{page.Total} playlists");
+                if (string.IsNullOrEmpty(page.Next)) break;
+                offset += limit;
+            }
+
+            _logger.LogInfo($"Total playlists fetched: {all.Count}");
+            return all;
+        }
+
+        /// <summary>
+        /// 获取歌单中的所有曲目（自动分页）。
+        /// </summary>
+        public async Task<List<SpotifyTrack>> GetPlaylistTracksAsync(string playlistId)
+        {
+            _logger.LogInfo($"Fetching tracks for playlist {playlistId}...");
+            var tracks = new List<SpotifyTrack>();
+            int offset = 0;
+            const int limit = 100;
+
+            while (true)
+            {
+                var page = await GetAsync<SpotifyPaged<SpotifyPlaylistTrackItem>>(
+                    $"/playlists/{playlistId}/tracks?limit={limit}&offset={offset}&fields=items(track(id,name,uri,duration_ms,explicit,popularity,artists(id,name),album(id,name,uri,images,release_date))),total,limit,offset,next");
+
+                if (page?.Items == null || page.Items.Count == 0) break;
+
+                foreach (var item in page.Items)
+                {
+                    // 过滤掉 null track（已删除或不可用的曲目）
+                    if (item?.Track != null && !string.IsNullOrEmpty(item.Track.Id))
+                        tracks.Add(item.Track);
+                }
+
+                if (string.IsNullOrEmpty(page.Next)) break;
+                offset += limit;
+            }
+
+            return tracks;
+        }
+
+        // =====================================================================
+        // Saved Tracks (用户收藏的音乐)
+        // =====================================================================
+
+        /// <summary>
+        /// 获取用户收藏的曲目（"Liked Songs"），自动分页。
+        /// </summary>
+        public async Task<List<SpotifyTrack>> GetSavedTracksAsync(int maxCount = 500)
+        {
+            var tracks = new List<SpotifyTrack>();
+            int offset = 0;
+            const int limit = 50;
+
+            while (tracks.Count < maxCount)
+            {
+                var page = await GetAsync<SpotifyPaged<SpotifySavedTrackItem>>($"/me/tracks?limit={limit}&offset={offset}");
+                if (page?.Items == null || page.Items.Count == 0) break;
+
+                foreach (var item in page.Items)
+                {
+                    if (item?.Track != null && !string.IsNullOrEmpty(item.Track.Id))
+                        tracks.Add(item.Track);
+                }
+
+                if (string.IsNullOrEmpty(page.Next)) break;
+                offset += limit;
+            }
+
+            return tracks;
+        }
+
+        /// <summary>
+        /// 检查曲目是否在用户收藏中。
+        /// </summary>
+        public async Task<Dictionary<string, bool>> CheckSavedTracksAsync(List<string> trackIds)
+        {
+            var result = new Dictionary<string, bool>();
+            // API 最多 50 个 ID
+            for (int i = 0; i < trackIds.Count; i += 50)
+            {
+                var batch = trackIds.GetRange(i, Math.Min(50, trackIds.Count - i));
+                var ids = string.Join(",", batch);
+                var checks = await GetAsync<List<bool>>($"/me/tracks/contains?ids={ids}");
+
+                if (checks != null)
+                {
+                    for (int j = 0; j < batch.Count && j < checks.Count; j++)
+                        result[batch[j]] = checks[j];
+                }
+            }
+            return result;
+        }
+
+        public async Task<bool> SaveTracksAsync(List<string> trackIds)
+        {
+            var body = JsonConvert.SerializeObject(new { ids = trackIds });
+            return await PutAsync("/me/tracks", body);
+        }
+
+        public async Task<bool> RemoveTracksAsync(List<string> trackIds)
+        {
+            var body = JsonConvert.SerializeObject(new { ids = trackIds });
+            return await DeleteAsync("/me/tracks", body);
+        }
+
+        // =====================================================================
+        // Player (Spotify Connect)
+        // =====================================================================
+
+        public async Task<SpotifyPlaybackState> GetPlaybackStateAsync()
+        {
+            // 可能返回 204 No Content（无活跃设备）
+            return await GetAsync<SpotifyPlaybackState>("/me/player", allowEmpty: true);
+        }
+
+        public async Task<List<SpotifyDevice>> GetAvailableDevicesAsync()
+        {
+            var resp = await GetAsync<SpotifyDevicesResponse>("/me/player/devices");
+            return resp?.Devices ?? new List<SpotifyDevice>();
+        }
+
+        /// <summary>
+        /// 播放指定曲目。
+        /// </summary>
+        /// <param name="trackUri">例如 "spotify:track:4iV5W9uYEdYUVa79Axb7Rh"</param>
+        /// <param name="deviceId">目标设备 ID，null 则使用当前活跃设备</param>
+        public async Task<bool> PlayTrackAsync(string trackUri, string deviceId = null)
+        {
+            var url = "/me/player/play";
+            if (!string.IsNullOrEmpty(deviceId))
+                url += $"?device_id={deviceId}";
+
+            var body = JsonConvert.SerializeObject(new
+            {
+                uris = new[] { trackUri },
+                position_ms = 0
+            });
+
+            return await PutAsync(url, body);
+        }
+
+        /// <summary>
+        /// 在某个播放上下文中播放（如歌单内顺序播放）。
+        /// </summary>
+        public async Task<bool> PlayContextAsync(string contextUri, string trackUri = null, string deviceId = null)
+        {
+            var url = "/me/player/play";
+            if (!string.IsNullOrEmpty(deviceId))
+                url += $"?device_id={deviceId}";
+
+            var bodyObj = new JObject { ["context_uri"] = contextUri };
+            if (!string.IsNullOrEmpty(trackUri))
+                bodyObj["offset"] = new JObject { ["uri"] = trackUri };
+
+            return await PutAsync(url, bodyObj.ToString());
+        }
+
+        public async Task<bool> PauseAsync()
+        {
+            return await PutAsync("/me/player/pause", null);
+        }
+
+        public async Task<bool> ResumeAsync()
+        {
+            return await PutAsync("/me/player/play", null);
+        }
+
+        public async Task<bool> SkipNextAsync()
+        {
+            return await PostAsync("/me/player/next");
+        }
+
+        public async Task<bool> SkipPreviousAsync()
+        {
+            return await PostAsync("/me/player/previous");
+        }
+
+        public async Task<bool> SeekAsync(int positionMs)
+        {
+            return await PutAsync($"/me/player/seek?position_ms={positionMs}", null);
+        }
+
+        public async Task<bool> SetVolumeAsync(int volumePercent)
+        {
+            volumePercent = Math.Max(0, Math.Min(100, volumePercent));
+            return await PutAsync($"/me/player/volume?volume_percent={volumePercent}", null);
+        }
+
+        public async Task<bool> SetRepeatAsync(string state)
+        {
+            // state: "off", "context", "track"
+            return await PutAsync($"/me/player/repeat?state={state}", null);
+        }
+
+        public async Task<bool> SetShuffleAsync(bool enabled)
+        {
+            return await PutAsync($"/me/player/shuffle?state={enabled.ToString().ToLower()}", null);
+        }
+
+        public async Task<bool> TransferPlaybackAsync(string deviceId, bool play = true)
+        {
+            var body = JsonConvert.SerializeObject(new
+            {
+                device_ids = new[] { deviceId },
+                play
+            });
+            return await PutAsync("/me/player", body);
+        }
+
+        // =====================================================================
+        // HTTP 辅助方法（带 401 自动刷新重试）
+        // =====================================================================
+
+        private async Task<T> GetAsync<T>(string endpoint, bool allowEmpty = false) where T : class
+        {
+            return await SendWithRetryAsync(async () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, ApiBase + endpoint);
+                SetAuthHeader(request);
+                return await _httpClient.SendAsync(request);
+            }, allowEmpty) is string json ? JsonConvert.DeserializeObject<T>(json) : default;
+        }
+
+        private async Task<bool> PutAsync(string endpoint, string body)
+        {
+            return await SendWithRetryAsync(async () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Put, ApiBase + endpoint);
+                SetAuthHeader(request);
+                if (body != null)
+                    request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+                return await _httpClient.SendAsync(request);
+            }, allowEmpty: true) != null;
+        }
+
+        private async Task<bool> PostAsync(string endpoint, string body = null)
+        {
+            return await SendWithRetryAsync(async () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, ApiBase + endpoint);
+                SetAuthHeader(request);
+                if (body != null)
+                    request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+                return await _httpClient.SendAsync(request);
+            }, allowEmpty: true) != null;
+        }
+
+        private async Task<bool> DeleteAsync(string endpoint, string body)
+        {
+            return await SendWithRetryAsync(async () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Delete, ApiBase + endpoint);
+                SetAuthHeader(request);
+                if (body != null)
+                    request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+                return await _httpClient.SendAsync(request);
+            }, allowEmpty: true) != null;
+        }
+
+        /// <summary>
+        /// 发送请求，401 时自动刷新 token 并重试一次。
+        /// 返回响应 body 字符串，或空请求返回 ""。失败返回 null。
+        /// </summary>
+        private async Task<string> SendWithRetryAsync(Func<Task<HttpResponseMessage>> requestFunc, bool allowEmpty = false)
+        {
+            if (!await EnsureTokenValidAsync())
+            {
+                _logger.LogWarning("No valid token available");
+                return null;
+            }
+
+            var response = await requestFunc();
+
+            // 401: 尝试刷新 token 后重试
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                _logger.LogInfo("Got 401, attempting token refresh...");
+                if (await RefreshTokenAsync())
+                {
+                    response = await requestFunc();
+                }
+                else
+                {
+                    _logger.LogError("Token refresh failed, user needs to re-login");
+                    return null;
+                }
+            }
+
+            // 204 No Content
+            if (response.StatusCode == HttpStatusCode.NoContent)
+                return allowEmpty ? "" : null;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync();
+                _logger.LogWarning($"Spotify API error {(int)response.StatusCode}: {errorBody}");
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        private void SetAuthHeader(HttpRequestMessage request)
+        {
+            if (_session != null && !string.IsNullOrEmpty(_session.AccessToken))
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _session.AccessToken);
+        }
+
+        public void Dispose()
+        {
+            _httpClient?.Dispose();
+        }
+    }
+}

--- a/ChillPatcher.Module.Spotify/SpotifyConfigWindow.cs
+++ b/ChillPatcher.Module.Spotify/SpotifyConfigWindow.cs
@@ -1,0 +1,378 @@
+using System;
+using UnityEngine;
+
+namespace ChillPatcher.Module.Spotify
+{
+    /// <summary>
+    /// Client ID 配置窗口 — 与 DeviceWindow 统一设计语言。
+    /// 半透明圆角窗体，贴近游戏 UI 风格。
+    /// </summary>
+    public class SpotifyConfigWindow : MonoBehaviour
+    {
+        private string _clientId = "";
+        private bool _visible = true;
+        private float _fadeAlpha;
+        private Action<string> _onSubmit;
+        private Action _onCancel;
+        private int _language;
+
+        private Rect _windowRect;
+        private bool _stylesInitialized;
+
+        // 纹理
+        private Texture2D _overlayTex;
+        private Texture2D _windowBgTex;
+        private Texture2D _fieldBgTex;
+        private Texture2D _fieldFocusTex;
+        private Texture2D _btnPrimaryTex;
+        private Texture2D _btnPrimaryHoverTex;
+        private Texture2D _btnDisabledTex;
+        private Texture2D _btnSecondaryTex;
+        private Texture2D _btnSecondaryHoverTex;
+        private Texture2D _separatorTex;
+
+        // 样式
+        private GUIStyle _windowStyle;
+        private GUIStyle _titleStyle;
+        private GUIStyle _subtitleStyle;
+        private GUIStyle _labelStyle;
+        private GUIStyle _fieldStyle;
+        private GUIStyle _hintStyle;
+        private GUIStyle _btnPrimaryStyle;
+        private GUIStyle _btnDisabledStyle;
+        private GUIStyle _btnSecondaryStyle;
+
+        private static readonly Color SpotifyGreen = new Color(0.114f, 0.725f, 0.329f, 1f);
+
+        public static SpotifyConfigWindow Show(Action<string> onSubmit, Action onCancel = null)
+        {
+            var go = new GameObject("SpotifyConfigWindow");
+            DontDestroyOnLoad(go);
+            var w = go.AddComponent<SpotifyConfigWindow>();
+            w._onSubmit = onSubmit;
+            w._onCancel = onCancel;
+            w._language = GetCurrentLanguage();
+            return w;
+        }
+
+        private void Start()
+        {
+            _windowRect = new Rect(
+                Screen.width / 2f - 200,
+                Screen.height / 2f - 140,
+                400, 280);
+        }
+
+        private void Update()
+        {
+            _fadeAlpha = Mathf.MoveTowards(_fadeAlpha, 1f, Time.unscaledDeltaTime * 6f);
+        }
+
+        private void OnDestroy()
+        {
+            D(_overlayTex); D(_windowBgTex); D(_fieldBgTex); D(_fieldFocusTex);
+            D(_btnPrimaryTex); D(_btnPrimaryHoverTex); D(_btnDisabledTex);
+            D(_btnSecondaryTex); D(_btnSecondaryHoverTex); D(_separatorTex);
+        }
+
+        private static void D(Texture2D t) { if (t != null) Destroy(t); }
+
+        // =====================================================================
+        // 多语言
+        // =====================================================================
+
+        private string L(string zh, string en, string ja)
+        {
+            switch (_language) { case 1: return ja; case 2: return en; default: return zh; }
+        }
+
+        private string TitleText => L("Spotify 配置", "Spotify Setup", "Spotify 設定");
+        private string SubText => L("连接你的 Spotify 开发者账号", "Connect your Spotify Developer account", "Spotify Developer アカウントを接続");
+        private string InputLabel => L("Client ID", "Client ID", "Client ID");
+        private string HintText => L(
+            "1. 前往 developer.spotify.com/dashboard 创建应用\n" +
+            "2. 复制 Client ID 粘贴到上方\n" +
+            "3. 添加 Redirect URI：fullstop://callback",
+            "1. Go to developer.spotify.com/dashboard, create an App\n" +
+            "2. Copy the Client ID and paste above\n" +
+            "3. Add Redirect URI: fullstop://callback",
+            "1. developer.spotify.com/dashboard でアプリを作成\n" +
+            "2. Client ID をコピーして上に貼り付け\n" +
+            "3. Redirect URI を追加：fullstop://callback"
+        );
+        private string CancelText => L("取消", "Cancel", "キャンセル");
+        private string OkText => L("连接", "Connect", "接続");
+
+        private static int GetCurrentLanguage()
+        {
+            try
+            {
+                var ct = Type.GetType("ChillPatcher.PluginConfig, ChillPatcher");
+                if (ct != null)
+                {
+                    var p = ct.GetProperty("DefaultLanguage",
+                        System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                    if (p != null)
+                    {
+                        var ce = p.GetValue(null);
+                        var vp = ce.GetType().GetProperty("Value");
+                        if (vp != null) return (int)vp.GetValue(ce);
+                    }
+                }
+            }
+            catch { }
+            return 3;
+        }
+
+        // =====================================================================
+        // 纹理（圆角）— 复用 DeviceWindow 的生成方法
+        // =====================================================================
+
+        private static Texture2D Solid(Color c)
+        {
+            var t = new Texture2D(4, 4);
+            var px = new Color[16];
+            for (int i = 0; i < 16; i++) px[i] = c;
+            t.SetPixels(px); t.Apply(); return t;
+        }
+
+        private static Texture2D RoundRect(int w, int h, int r, Color fill)
+        {
+            var t = new Texture2D(w, h);
+            var clear = new Color(0, 0, 0, 0);
+            for (int y = 0; y < h; y++)
+                for (int x = 0; x < w; x++)
+                    t.SetPixel(x, y, InRR(x, y, w, h, r) ? fill : clear);
+            t.Apply();
+            t.filterMode = FilterMode.Bilinear;
+            return t;
+        }
+
+        private static bool InRR(int x, int y, int w, int h, int r)
+        {
+            if (x < r && y < r) return Dist(x, y, r, r) <= r;
+            if (x >= w - r && y < r) return Dist(x, y, w - r - 1, r) <= r;
+            if (x < r && y >= h - r) return Dist(x, y, r, h - r - 1) <= r;
+            if (x >= w - r && y >= h - r) return Dist(x, y, w - r - 1, h - r - 1) <= r;
+            return true;
+        }
+
+        private static float Dist(int x1, int y1, int x2, int y2)
+        {
+            return Mathf.Sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+        }
+
+        // =====================================================================
+        // 样式
+        // =====================================================================
+
+        private void InitStyles()
+        {
+            if (_stylesInitialized) return;
+            _stylesInitialized = true;
+
+            var winW = (int)_windowRect.width;
+            var winH = (int)_windowRect.height;
+
+            _overlayTex = Solid(new Color(0, 0, 0, 0.45f));
+            _windowBgTex = RoundRect(winW, winH, 14, new Color(0.08f, 0.08f, 0.12f, 0.92f));
+            _fieldBgTex = RoundRect(winW - 48, 34, 8, new Color(1f, 1f, 1f, 0.06f));
+            _fieldFocusTex = RoundRect(winW - 48, 34, 8, new Color(1f, 1f, 1f, 0.10f));
+            _btnPrimaryTex = RoundRect(120, 34, 8, SpotifyGreen);
+            _btnPrimaryHoverTex = RoundRect(120, 34, 8, new Color(0.13f, 0.82f, 0.38f, 1f));
+            _btnDisabledTex = RoundRect(120, 34, 8, new Color(1f, 1f, 1f, 0.06f));
+            _btnSecondaryTex = RoundRect(100, 34, 8, new Color(1f, 1f, 1f, 0.06f));
+            _btnSecondaryHoverTex = RoundRect(100, 34, 8, new Color(1f, 1f, 1f, 0.14f));
+            _separatorTex = Solid(new Color(1f, 1f, 1f, 0.08f));
+
+            _windowStyle = new GUIStyle
+            {
+                normal = { background = _windowBgTex },
+                border = new RectOffset(14, 14, 14, 14),
+                padding = new RectOffset(0, 0, 0, 0)
+            };
+
+            _titleStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 15,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = new Color(0.95f, 0.95f, 0.97f) }
+            };
+
+            _subtitleStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 11,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = new Color(0.6f, 0.6f, 0.65f) }
+            };
+
+            _labelStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 12,
+                normal = { textColor = new Color(0.7f, 0.7f, 0.73f) },
+                padding = new RectOffset(24, 24, 0, 0)
+            };
+
+            _fieldStyle = new GUIStyle(GUI.skin.textField)
+            {
+                fontSize = 13,
+                fixedHeight = 34,
+                normal = { background = _fieldBgTex, textColor = new Color(0.92f, 0.92f, 0.94f) },
+                focused = { background = _fieldFocusTex, textColor = Color.white },
+                hover = { background = _fieldBgTex, textColor = new Color(0.92f, 0.92f, 0.94f) },
+                border = new RectOffset(8, 8, 8, 8),
+                padding = new RectOffset(12, 12, 8, 8)
+            };
+
+            _hintStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 11,
+                wordWrap = true,
+                normal = { textColor = new Color(0.5f, 0.5f, 0.55f) },
+                padding = new RectOffset(24, 24, 0, 0)
+            };
+
+            _btnPrimaryStyle = new GUIStyle(GUI.skin.button)
+            {
+                fontSize = 13,
+                fontStyle = FontStyle.Bold,
+                fixedHeight = 34,
+                normal = { background = _btnPrimaryTex, textColor = Color.white },
+                hover = { background = _btnPrimaryHoverTex, textColor = Color.white },
+                active = { background = _btnPrimaryTex, textColor = Color.white },
+                border = new RectOffset(8, 8, 8, 8),
+                padding = new RectOffset(16, 16, 4, 4)
+            };
+
+            _btnDisabledStyle = new GUIStyle(_btnPrimaryStyle)
+            {
+                normal = { background = _btnDisabledTex, textColor = new Color(0.4f, 0.4f, 0.43f) },
+                hover = { background = _btnDisabledTex, textColor = new Color(0.4f, 0.4f, 0.43f) },
+                active = { background = _btnDisabledTex, textColor = new Color(0.4f, 0.4f, 0.43f) }
+            };
+
+            _btnSecondaryStyle = new GUIStyle(GUI.skin.button)
+            {
+                fontSize = 12,
+                fixedHeight = 34,
+                normal = { background = _btnSecondaryTex, textColor = new Color(0.7f, 0.7f, 0.73f) },
+                hover = { background = _btnSecondaryHoverTex, textColor = new Color(0.95f, 0.95f, 0.97f) },
+                active = { background = _btnSecondaryTex, textColor = new Color(0.95f, 0.95f, 0.97f) },
+                border = new RectOffset(8, 8, 8, 8),
+                padding = new RectOffset(16, 16, 4, 4)
+            };
+        }
+
+        // =====================================================================
+        // 绘制
+        // =====================================================================
+
+        private void OnGUI()
+        {
+            if (!_visible) return;
+            InitStyles();
+
+            var saved = GUI.color;
+            GUI.color = new Color(1, 1, 1, _fadeAlpha);
+            GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), _overlayTex);
+
+            // 点击遮罩关闭
+            if (Event.current.type == EventType.MouseDown
+                && !_windowRect.Contains(Event.current.mousePosition))
+            {
+                Close();
+                _onCancel?.Invoke();
+                Event.current.Use();
+                GUI.color = saved;
+                return;
+            }
+
+            _windowRect = GUI.Window(98765, _windowRect, DrawWindow, "", _windowStyle);
+            GUI.color = saved;
+        }
+
+        private void DrawWindow(int windowId)
+        {
+            GUILayout.Space(16);
+            GUILayout.Label(TitleText, _titleStyle);
+            GUILayout.Space(1);
+            GUILayout.Label(SubText, _subtitleStyle);
+            GUILayout.Space(10);
+
+            // 分隔线
+            DrawSep();
+            GUILayout.Space(10);
+
+            // Client ID 标签
+            GUILayout.Label(InputLabel, _labelStyle);
+            GUILayout.Space(4);
+
+            // 输入框（两侧留白）
+            GUILayout.BeginHorizontal();
+            GUILayout.Space(24);
+            GUI.SetNextControlName("ClientIdField");
+            _clientId = GUILayout.TextField(_clientId, _fieldStyle);
+            GUILayout.Space(24);
+            GUILayout.EndHorizontal();
+            GUILayout.Space(8);
+
+            // 提示
+            GUILayout.Label(HintText, _hintStyle);
+
+            GUILayout.FlexibleSpace();
+
+            // 分隔线
+            DrawSep();
+            GUILayout.Space(10);
+
+            // 按钮区
+            GUILayout.BeginHorizontal();
+            GUILayout.Space(24);
+
+            if (GUILayout.Button(CancelText, _btnSecondaryStyle, GUILayout.Width(100)))
+            {
+                Close();
+                _onCancel?.Invoke();
+            }
+
+            GUILayout.FlexibleSpace();
+
+            var valid = !string.IsNullOrWhiteSpace(_clientId)
+                && _clientId.Length >= 10
+                && _clientId != "YOUR_SPOTIFY_CLIENT_ID";
+
+            if (valid)
+            {
+                if (GUILayout.Button(OkText, _btnPrimaryStyle, GUILayout.Width(120)))
+                {
+                    Close();
+                    _onSubmit?.Invoke(_clientId.Trim());
+                }
+            }
+            else
+            {
+                GUILayout.Button(OkText, _btnDisabledStyle, GUILayout.Width(120));
+            }
+
+            GUILayout.Space(24);
+            GUILayout.EndHorizontal();
+            GUILayout.Space(12);
+
+            GUI.DragWindow(new Rect(0, 0, _windowRect.width, 56));
+        }
+
+        private void DrawSep()
+        {
+            var r = GUILayoutUtility.GetRect(0, 1, GUILayout.ExpandWidth(true));
+            r.x += 16; r.width -= 32;
+            GUI.DrawTexture(r, _separatorTex);
+        }
+
+        private void Close()
+        {
+            _visible = false;
+            Destroy(gameObject);
+        }
+    }
+}

--- a/ChillPatcher.Module.Spotify/SpotifyDeviceWindow.cs
+++ b/ChillPatcher.Module.Spotify/SpotifyDeviceWindow.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ChillPatcher.Module.Spotify
+{
+    /// <summary>
+    /// 设备选择弹窗 — 贴近游戏 UI 风格（半透明、圆角、柔和色调）。
+    /// </summary>
+    public class SpotifyDeviceWindow : MonoBehaviour
+    {
+        private List<SpotifyDevice> _devices;
+        private string _activeDeviceId;
+        private Action<SpotifyDevice> _onSelect;
+        private Action _onCancel;
+        private bool _visible = true;
+        private int _language;
+        private float _fadeAlpha;
+
+        private Rect _windowRect;
+        private Vector2 _scrollPos;
+        private bool _stylesInitialized;
+
+        // 纹理
+        private Texture2D _windowBgTex;
+        private Texture2D _overlayTex;
+        private Texture2D _cardNormalTex;
+        private Texture2D _cardHoverTex;
+        private Texture2D _cardActiveTex;
+        private Texture2D _accentDotTex;
+        private Texture2D _closeBtnTex;
+        private Texture2D _closeBtnHoverTex;
+        private Texture2D _separatorTex;
+
+        // 样式
+        private GUIStyle _windowStyle;
+        private GUIStyle _titleStyle;
+        private GUIStyle _subtitleStyle;
+        private GUIStyle _emptyStyle;
+        private GUIStyle _closeStyle;
+
+        // 颜色
+        private static readonly Color SpotifyGreen = new Color(0.114f, 0.725f, 0.329f, 1f);
+
+        public static SpotifyDeviceWindow Show(
+            List<SpotifyDevice> devices,
+            string activeDeviceId,
+            Action<SpotifyDevice> onSelect,
+            Action onCancel = null)
+        {
+            var go = new GameObject("SpotifyDeviceWindow");
+            DontDestroyOnLoad(go);
+            var w = go.AddComponent<SpotifyDeviceWindow>();
+            w._devices = devices ?? new List<SpotifyDevice>();
+            w._activeDeviceId = activeDeviceId;
+            w._onSelect = onSelect;
+            w._onCancel = onCancel;
+            w._language = GetCurrentLanguage();
+            return w;
+        }
+
+        private void Start()
+        {
+            var rows = Mathf.Max(_devices.Count, 1);
+            var h = Mathf.Min(90 + rows * 58 + 56, 440);
+            _windowRect = new Rect(
+                Screen.width / 2f - 200,
+                Screen.height / 2f - h / 2f,
+                400, h);
+        }
+
+        private void Update()
+        {
+            _fadeAlpha = Mathf.MoveTowards(_fadeAlpha, 1f, Time.unscaledDeltaTime * 6f);
+        }
+
+        private void OnDestroy()
+        {
+            Tex.Destroy(_windowBgTex);
+            Tex.Destroy(_overlayTex);
+            Tex.Destroy(_cardNormalTex);
+            Tex.Destroy(_cardHoverTex);
+            Tex.Destroy(_cardActiveTex);
+            Tex.Destroy(_accentDotTex);
+            Tex.Destroy(_closeBtnTex);
+            Tex.Destroy(_closeBtnHoverTex);
+            Tex.Destroy(_separatorTex);
+        }
+
+        // =====================================================================
+        // 多语言
+        // =====================================================================
+
+        private string L(string zh, string en, string ja)
+        {
+            switch (_language) { case 1: return ja; case 2: return en; default: return zh; }
+        }
+
+        private string TitleText => L("选择播放设备", "Select Device", "デバイスを選択");
+        private string SubText => L("选择 Spotify 播放设备", "Choose a Spotify device", "Spotify デバイスを選択");
+        private string EmptyText => L("未找到设备，请打开 Spotify", "No devices found. Open Spotify.", "デバイスが見つかりません");
+        private string ActiveText => L("正在使用", "Active", "使用中");
+        private string CloseText => L("关闭", "Close", "閉じる");
+
+        private static string DeviceTypeLabel(string type)
+        {
+            if (string.IsNullOrEmpty(type)) return "";
+            switch (type.ToLower())
+            {
+                case "computer": return "Computer";
+                case "smartphone": return "Phone";
+                case "speaker": return "Speaker";
+                case "tv": return "TV";
+                case "tablet": return "Tablet";
+                default: return type;
+            }
+        }
+
+        private static int GetCurrentLanguage()
+        {
+            try
+            {
+                var ct = Type.GetType("ChillPatcher.PluginConfig, ChillPatcher");
+                if (ct != null)
+                {
+                    var p = ct.GetProperty("DefaultLanguage", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                    if (p != null)
+                    {
+                        var ce = p.GetValue(null);
+                        var vp = ce.GetType().GetProperty("Value");
+                        if (vp != null) return (int)vp.GetValue(ce);
+                    }
+                }
+            }
+            catch { }
+            return 3;
+        }
+
+        // =====================================================================
+        // 纹理生成（圆角）
+        // =====================================================================
+
+        private static class Tex
+        {
+            public static Texture2D Solid(Color c)
+            {
+                var t = new Texture2D(4, 4);
+                var px = new Color[16];
+                for (int i = 0; i < 16; i++) px[i] = c;
+                t.SetPixels(px); t.Apply(); return t;
+            }
+
+            public static Texture2D RoundRect(int w, int h, int r, Color fill)
+            {
+                var t = new Texture2D(w, h);
+                var clear = new Color(0, 0, 0, 0);
+                for (int y = 0; y < h; y++)
+                    for (int x = 0; x < w; x++)
+                        t.SetPixel(x, y, IsInsideRoundRect(x, y, w, h, r) ? fill : clear);
+                t.Apply();
+                t.filterMode = FilterMode.Bilinear;
+                return t;
+            }
+
+            private static bool IsInsideRoundRect(int x, int y, int w, int h, int r)
+            {
+                // 四个角检查圆弧
+                if (x < r && y < r) return Dist(x, y, r, r) <= r;
+                if (x >= w - r && y < r) return Dist(x, y, w - r - 1, r) <= r;
+                if (x < r && y >= h - r) return Dist(x, y, r, h - r - 1) <= r;
+                if (x >= w - r && y >= h - r) return Dist(x, y, w - r - 1, h - r - 1) <= r;
+                return true;
+            }
+
+            private static float Dist(int x1, int y1, int x2, int y2)
+            {
+                return Mathf.Sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+            }
+
+            public static void Destroy(Texture2D t) { if (t != null) UnityEngine.Object.Destroy(t); }
+        }
+
+        // =====================================================================
+        // 样式初始化
+        // =====================================================================
+
+        private void InitStyles()
+        {
+            if (_stylesInitialized) return;
+            _stylesInitialized = true;
+
+            var winW = (int)_windowRect.width;
+            var winH = (int)_windowRect.height;
+
+            // 半透明毛玻璃风格（贴近游戏）
+            _windowBgTex = Tex.RoundRect(winW, winH, 14, new Color(0.08f, 0.08f, 0.12f, 0.92f));
+            _overlayTex = Tex.Solid(new Color(0, 0, 0, 0.45f));
+            _cardNormalTex = Tex.RoundRect(winW - 32, 52, 8, new Color(1f, 1f, 1f, 0.05f));
+            _cardHoverTex = Tex.RoundRect(winW - 32, 52, 8, new Color(1f, 1f, 1f, 0.12f));
+            _cardActiveTex = Tex.RoundRect(winW - 32, 52, 8, new Color(0.114f, 0.725f, 0.329f, 0.15f));
+            _accentDotTex = Tex.Solid(SpotifyGreen);
+            _closeBtnTex = Tex.RoundRect(80, 28, 6, new Color(1f, 1f, 1f, 0.06f));
+            _closeBtnHoverTex = Tex.RoundRect(80, 28, 6, new Color(1f, 1f, 1f, 0.14f));
+            _separatorTex = Tex.Solid(new Color(1f, 1f, 1f, 0.08f));
+
+            _windowStyle = new GUIStyle
+            {
+                normal = { background = _windowBgTex },
+                border = new RectOffset(14, 14, 14, 14),
+                padding = new RectOffset(0, 0, 0, 0)
+            };
+
+            _titleStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 15,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = new Color(0.95f, 0.95f, 0.97f) }
+            };
+
+            _subtitleStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 11,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = new Color(0.6f, 0.6f, 0.65f) }
+            };
+
+            _emptyStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 12,
+                wordWrap = true,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = new Color(0.5f, 0.5f, 0.55f) }
+            };
+
+            _closeStyle = new GUIStyle(GUI.skin.button)
+            {
+                fontSize = 12,
+                fixedHeight = 28,
+                normal = { background = _closeBtnTex, textColor = new Color(0.7f, 0.7f, 0.73f) },
+                hover = { background = _closeBtnHoverTex, textColor = new Color(0.95f, 0.95f, 0.97f) },
+                active = { background = _closeBtnTex, textColor = new Color(0.95f, 0.95f, 0.97f) },
+                border = new RectOffset(6, 6, 6, 6),
+                padding = new RectOffset(16, 16, 2, 2)
+            };
+        }
+
+        // =====================================================================
+        // 绘制
+        // =====================================================================
+
+        private void OnGUI()
+        {
+            if (!_visible) return;
+            InitStyles();
+
+            // 淡入遮罩
+            var savedColor = GUI.color;
+            GUI.color = new Color(1, 1, 1, _fadeAlpha);
+            GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), _overlayTex);
+
+            // 点击遮罩关闭
+            if (Event.current.type == EventType.MouseDown
+                && !_windowRect.Contains(Event.current.mousePosition))
+            {
+                Close();
+                _onCancel?.Invoke();
+                Event.current.Use();
+                GUI.color = savedColor;
+                return;
+            }
+
+            _windowRect = GUI.Window(98766, _windowRect, DrawWindow, "", _windowStyle);
+            GUI.color = savedColor;
+        }
+
+        private void DrawWindow(int id)
+        {
+            GUILayout.Space(16);
+            GUILayout.Label(TitleText, _titleStyle);
+            GUILayout.Space(1);
+            GUILayout.Label(SubText, _subtitleStyle);
+            GUILayout.Space(10);
+
+            // 分隔线
+            DrawSeparator();
+            GUILayout.Space(6);
+
+            if (_devices.Count == 0)
+            {
+                GUILayout.FlexibleSpace();
+                GUILayout.Label(EmptyText, _emptyStyle);
+                GUILayout.FlexibleSpace();
+            }
+            else
+            {
+                _scrollPos = GUILayout.BeginScrollView(_scrollPos, false, false,
+                    GUIStyle.none, GUIStyle.none, GUIStyle.none);
+
+                foreach (var device in _devices)
+                {
+                    DrawDeviceRow(device);
+                    GUILayout.Space(3);
+                }
+
+                GUILayout.EndScrollView();
+            }
+
+            GUILayout.Space(6);
+            DrawSeparator();
+            GUILayout.Space(8);
+
+            // 关闭按钮
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button(CloseText, _closeStyle, GUILayout.Width(80)))
+            {
+                Close();
+                _onCancel?.Invoke();
+            }
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+            GUILayout.Space(10);
+
+            // 只允许标题区拖动
+            GUI.DragWindow(new Rect(0, 0, _windowRect.width, 56));
+        }
+
+        private void DrawDeviceRow(SpotifyDevice device)
+        {
+            var isActive = device.Id == _activeDeviceId || device.IsActive;
+            var rect = GUILayoutUtility.GetRect(0, 52, GUILayout.ExpandWidth(true));
+
+            // 内缩 16px
+            var cardRect = new Rect(rect.x + 16, rect.y, rect.width - 32, rect.height);
+            var isHover = cardRect.Contains(Event.current.mousePosition);
+
+            // 卡片背景
+            var bg = isActive ? _cardActiveTex : (isHover ? _cardHoverTex : _cardNormalTex);
+            GUI.DrawTexture(cardRect, bg, ScaleMode.StretchToFill);
+
+            // 活跃指示条（左侧 3px 圆角条）
+            if (isActive)
+            {
+                var barRect = new Rect(cardRect.x + 1, cardRect.y + 10, 3, cardRect.height - 20);
+                GUI.DrawTexture(barRect, _accentDotTex);
+            }
+
+            // 设备名称（截断过长名称）
+            var nameColor = isActive ? SpotifyGreen : new Color(0.92f, 0.92f, 0.94f);
+            var nameRect = new Rect(cardRect.x + 14, cardRect.y + 8, cardRect.width - 100, 20);
+            var nameStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 13,
+                fontStyle = isActive ? FontStyle.Bold : FontStyle.Normal,
+                normal = { textColor = nameColor },
+                clipping = TextClipping.Clip
+            };
+            GUI.Label(nameRect, device.Name ?? "Unknown", nameStyle);
+
+            // 设备类型（第二行小字）
+            var typeLabel = DeviceTypeLabel(device.Type);
+            if (device.VolumePercent.HasValue)
+                typeLabel += $"  ·  Vol {device.VolumePercent}%";
+            var typeRect = new Rect(cardRect.x + 14, cardRect.y + 28, cardRect.width - 100, 18);
+            var typeStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 10,
+                normal = { textColor = new Color(0.5f, 0.5f, 0.55f) }
+            };
+            GUI.Label(typeRect, typeLabel, typeStyle);
+
+            // 右侧状态
+            if (isActive)
+            {
+                // 绿色圆点 + 状态文字
+                var dotRect = new Rect(cardRect.xMax - 78, cardRect.y + 20, 6, 6);
+                GUI.DrawTexture(dotRect, _accentDotTex);
+
+                var statusRect = new Rect(cardRect.xMax - 68, cardRect.y + 15, 58, 20);
+                var statusStyle = new GUIStyle(GUI.skin.label)
+                {
+                    fontSize = 10,
+                    normal = { textColor = SpotifyGreen }
+                };
+                GUI.Label(statusRect, ActiveText, statusStyle);
+            }
+
+            // 点击
+            if (Event.current.type == EventType.MouseDown && isHover)
+            {
+                Event.current.Use();
+                Close();
+                _onSelect?.Invoke(device);
+            }
+        }
+
+        private void DrawSeparator()
+        {
+            var r = GUILayoutUtility.GetRect(0, 1, GUILayout.ExpandWidth(true));
+            r.x += 16; r.width -= 32;
+            GUI.DrawTexture(r, _separatorTex);
+        }
+
+        private void Close()
+        {
+            _visible = false;
+            Destroy(gameObject);
+        }
+    }
+}

--- a/ChillPatcher.Module.Spotify/SpotifyModels.cs
+++ b/ChillPatcher.Module.Spotify/SpotifyModels.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace ChillPatcher.Module.Spotify
+{
+    public class SpotifySession
+    {
+        public string AccessToken { get; set; }
+        public string RefreshToken { get; set; }
+        public DateTime ExpiresAt { get; set; }
+        public string UserId { get; set; }
+        public string DisplayName { get; set; }
+        public string Product { get; set; } // "premium" or "free"
+
+        [JsonIgnore]
+        public bool IsValid => !string.IsNullOrEmpty(AccessToken) && !string.IsNullOrEmpty(RefreshToken);
+
+        [JsonIgnore]
+        public bool IsExpired => DateTime.UtcNow >= ExpiresAt.AddMinutes(-5);
+
+        [JsonIgnore]
+        public bool IsPremium => string.Equals(Product, "premium", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ========== User ==========
+
+    public class SpotifyUser
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("display_name")] public string DisplayName { get; set; }
+        [JsonProperty("email")] public string Email { get; set; }
+        [JsonProperty("country")] public string Country { get; set; }
+        [JsonProperty("product")] public string Product { get; set; }
+        [JsonProperty("images")] public List<SpotifyImage> Images { get; set; }
+    }
+
+    public class SpotifyImage
+    {
+        [JsonProperty("url")] public string Url { get; set; }
+        [JsonProperty("width")] public int? Width { get; set; }
+        [JsonProperty("height")] public int? Height { get; set; }
+    }
+
+    // ========== Track ==========
+
+    public class SpotifyTrack
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("name")] public string Name { get; set; }
+        [JsonProperty("uri")] public string Uri { get; set; }
+        [JsonProperty("duration_ms")] public int DurationMs { get; set; }
+        [JsonProperty("explicit")] public bool Explicit { get; set; }
+        [JsonProperty("popularity")] public int Popularity { get; set; }
+        [JsonProperty("preview_url")] public string PreviewUrl { get; set; }
+        [JsonProperty("track_number")] public int TrackNumber { get; set; }
+        [JsonProperty("artists")] public List<SpotifyArtist> Artists { get; set; }
+        [JsonProperty("album")] public SpotifyAlbum Album { get; set; }
+        [JsonProperty("external_urls")] public Dictionary<string, string> ExternalUrls { get; set; }
+
+        [JsonIgnore]
+        public string ArtistName => Artists != null && Artists.Count > 0
+            ? string.Join(", ", Artists.ConvertAll(a => a.Name))
+            : "Unknown";
+
+        [JsonIgnore]
+        public float DurationSeconds => DurationMs / 1000f;
+
+        [JsonIgnore]
+        public string BestCoverUrl
+        {
+            get
+            {
+                if (Album?.Images == null || Album.Images.Count == 0) return null;
+                // 优先取 300x300 左右的中等尺寸
+                foreach (var img in Album.Images)
+                    if (img.Width >= 200 && img.Width <= 400) return img.Url;
+                return Album.Images[0].Url;
+            }
+        }
+    }
+
+    public class SpotifyArtist
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("name")] public string Name { get; set; }
+    }
+
+    public class SpotifyAlbum
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("name")] public string Name { get; set; }
+        [JsonProperty("uri")] public string Uri { get; set; }
+        [JsonProperty("release_date")] public string ReleaseDate { get; set; }
+        [JsonProperty("images")] public List<SpotifyImage> Images { get; set; }
+
+        [JsonIgnore]
+        public string BestCoverUrl
+        {
+            get
+            {
+                if (Images == null || Images.Count == 0) return null;
+                foreach (var img in Images)
+                    if (img.Width >= 200 && img.Width <= 400) return img.Url;
+                return Images[0].Url;
+            }
+        }
+    }
+
+    // ========== Playlist ==========
+
+    public class SpotifyPlaylist
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("name")] public string Name { get; set; }
+        [JsonProperty("description")] public string Description { get; set; }
+        [JsonProperty("images")] public List<SpotifyImage> Images { get; set; }
+        [JsonProperty("owner")] public SpotifyPlaylistOwner Owner { get; set; }
+        [JsonProperty("tracks")] public SpotifyPlaylistTracksRef Tracks { get; set; }
+
+        [JsonIgnore]
+        public string BestCoverUrl
+        {
+            get
+            {
+                if (Images == null || Images.Count == 0) return null;
+                return Images[0].Url;
+            }
+        }
+    }
+
+    public class SpotifyPlaylistOwner
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("display_name")] public string DisplayName { get; set; }
+    }
+
+    public class SpotifyPlaylistTracksRef
+    {
+        [JsonProperty("total")] public int Total { get; set; }
+    }
+
+    public class SpotifyPlaylistTrackItem
+    {
+        [JsonProperty("track")] public SpotifyTrack Track { get; set; }
+        [JsonProperty("added_at")] public string AddedAt { get; set; }
+    }
+
+    // ========== Playback (Connect) ==========
+
+    public class SpotifyPlaybackState
+    {
+        [JsonProperty("is_playing")] public bool IsPlaying { get; set; }
+        [JsonProperty("progress_ms")] public int? ProgressMs { get; set; }
+        [JsonProperty("item")] public SpotifyTrack Item { get; set; }
+        [JsonProperty("device")] public SpotifyDevice Device { get; set; }
+        [JsonProperty("repeat_state")] public string RepeatState { get; set; }
+        [JsonProperty("shuffle_state")] public bool ShuffleState { get; set; }
+        [JsonProperty("timestamp")] public long Timestamp { get; set; }
+    }
+
+    public class SpotifyDevice
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("name")] public string Name { get; set; }
+        [JsonProperty("type")] public string Type { get; set; }
+        [JsonProperty("is_active")] public bool IsActive { get; set; }
+        [JsonProperty("is_restricted")] public bool IsRestricted { get; set; }
+        [JsonProperty("volume_percent")] public int? VolumePercent { get; set; }
+    }
+
+    public class SpotifyDevicesResponse
+    {
+        [JsonProperty("devices")] public List<SpotifyDevice> Devices { get; set; }
+    }
+
+    // ========== Paginated Response ==========
+
+    public class SpotifyPaged<T>
+    {
+        [JsonProperty("items")] public List<T> Items { get; set; }
+        [JsonProperty("total")] public int Total { get; set; }
+        [JsonProperty("limit")] public int Limit { get; set; }
+        [JsonProperty("offset")] public int Offset { get; set; }
+        [JsonProperty("next")] public string Next { get; set; }
+    }
+
+    // ========== Token Response ==========
+
+    public class SpotifyTokenResponse
+    {
+        [JsonProperty("access_token")] public string AccessToken { get; set; }
+        [JsonProperty("refresh_token")] public string RefreshToken { get; set; }
+        [JsonProperty("expires_in")] public int ExpiresIn { get; set; }
+        [JsonProperty("token_type")] public string TokenType { get; set; }
+    }
+
+    // ========== Library (Saved Tracks) ==========
+
+    public class SpotifySavedTrackItem
+    {
+        [JsonProperty("track")] public SpotifyTrack Track { get; set; }
+        [JsonProperty("added_at")] public string AddedAt { get; set; }
+    }
+}

--- a/ChillPatcher.Module.Spotify/SpotifyModule.cs
+++ b/ChillPatcher.Module.Spotify/SpotifyModule.cs
@@ -1,0 +1,767 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using BepInEx.Configuration;
+using BepInEx.Logging;
+using ChillPatcher.SDK.Attributes;
+using ChillPatcher.SDK.Events;
+using ChillPatcher.SDK.Interfaces;
+using ChillPatcher.SDK.Models;
+using Newtonsoft.Json;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace ChillPatcher.Module.Spotify
+{
+    [MusicModule("com.chillpatcher.spotify", "Spotify",
+        Version = "1.0.0",
+        Author = "ChillPatcher",
+        Description = "Spotify Connect playback control and playlist sync")]
+    public class SpotifyModule : IMusicModule, IStreamingMusicSourceProvider, ICoverProvider, IFavoriteExcludeHandler
+    {
+        public string ModuleId => "com.chillpatcher.spotify";
+        public string DisplayName => "Spotify";
+        public string Version => "1.0.0";
+        public int Priority => 20;
+
+        public ModuleCapabilities Capabilities => new ModuleCapabilities
+        {
+            CanDelete = false,
+            CanFavorite = true,   // 收藏持久化在 Spotify 服务端
+            CanExclude = false,
+            SupportsLiveUpdate = false,
+            ProvidesCover = true,
+            ProvidesAlbum = true
+        };
+
+        public MusicSourceType SourceType => MusicSourceType.Stream;
+        public bool IsReady => _bridge != null && _bridge.IsLoggedIn;
+        public event Action<bool> OnReadyStateChanged;
+
+        private IModuleContext _context;
+        private ManualLogSource _logger;
+        private SpotifyBridge _bridge;
+        private OAuthManager _oauthManager;
+        private SpotifySongRegistry _registry;
+
+        private string _dataPath;
+        private string _clientId;
+        private string _pluginPath;
+
+        // 封面缓存
+        private readonly Dictionary<string, Sprite> _spriteCache = new Dictionary<string, Sprite>();
+
+        // 收藏状态缓存 (Spotify track ID -> saved)，初始数据来自 Liked Songs 加载
+        private readonly Dictionary<string, bool> _savedCache = new Dictionary<string, bool>();
+
+
+        // OAuth 登录进行中标志
+        private bool _isLoggingIn;
+
+        // Client ID 未配置标志
+        private bool _needsClientId;
+
+        // 当前选定的设备
+        private string _activeDeviceId;
+        private string _activeDeviceName;
+
+        // 事件订阅
+        private IDisposable _pauseSubscription;
+
+        // Win32 API: 授权完成后将游戏窗口拉回前台
+        [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
+        [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
+        [DllImport("user32.dll")] private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+        [DllImport("kernel32.dll")] private static extern uint GetCurrentProcessId();
+        [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+        [DllImport("user32.dll")] private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+        [DllImport("user32.dll")] private static extern bool IsWindowVisible(IntPtr hWnd);
+        private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+        // =====================================================================
+        // 生命周期
+        // =====================================================================
+
+        public async Task InitializeAsync(IModuleContext context)
+        {
+            _context = context;
+            _logger = context.Logger;
+            _logger.LogInfo("Spotify module initializing...");
+
+            // 数据目录
+            _pluginPath = Path.GetDirectoryName(typeof(SpotifyModule).Assembly.Location);
+            _dataPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "ChillPatcher", ModuleId);
+            Directory.CreateDirectory(_dataPath);
+
+            // 读取配置
+            LoadConfig(_pluginPath);
+            _logger.LogInfo($"Config loaded: ClientId={(string.IsNullOrEmpty(_clientId) ? "(empty)" : _clientId.Substring(0, Math.Min(8, _clientId.Length)) + "...")}");
+
+
+            if (string.IsNullOrEmpty(_clientId) || _clientId == "YOUR_SPOTIFY_CLIENT_ID")
+            {
+                _logger.LogWarning("Spotify Client ID not configured. Will prompt on first play.");
+                _needsClientId = true;
+                _registry = new SpotifySongRegistry(_context, ModuleId);
+                _registry.RegisterLoginSong(">>> 点击播放以配置 Spotify <<<");
+                OnReadyStateChanged?.Invoke(false);
+                return;
+            }
+
+            // 初始化组件
+            await InitWithClientIdAsync();
+        }
+
+        private void ShowConfigWindow()
+        {
+            _logger.LogInfo("Showing Spotify Client ID configuration window");
+            SpotifyConfigWindow.Show(
+                onSubmit: async (clientId) =>
+                {
+                    _logger.LogInfo("Client ID submitted via config window");
+                    _clientId = clientId;
+                    _needsClientId = false;
+                    SaveClientId(clientId);
+
+                    _registry.UpdateLoginStatus("Client ID 已保存，正在初始化...");
+
+                    // 初始化 Bridge 和 OAuthManager（不走 InitWithClientIdAsync 以避免注册新登录歌曲）
+                    _bridge = new SpotifyBridge(_clientId, _dataPath, _logger);
+                    InitOAuthManager();
+                    SubscribePlaybackEvents();
+
+                    // 直接启动 OAuth 登录流程
+                    _logger.LogInfo("Starting OAuth flow after config...");
+                    _ = Task.Run(() => _oauthManager.StartLoginAsync());
+                },
+                onCancel: () =>
+                {
+                    _logger.LogInfo("Spotify config window cancelled");
+                    _isLoggingIn = false;
+                    _registry.UpdateLoginStatus(">>> 点击播放以配置 Spotify <<<");
+                }
+            );
+        }
+
+        private void SaveClientId(string clientId)
+        {
+            var bepInExConfigPath = Path.Combine(_pluginPath, "..", "..", "config", "com.chillpatcher.plugin.cfg");
+            var configFile = new ConfigFile(bepInExConfigPath, false);
+            var entry = configFile.Bind(
+                $"Module:{ModuleId}",
+                "ClientId",
+                "YOUR_SPOTIFY_CLIENT_ID",
+                "Spotify Developer App Client ID.");
+            entry.Value = clientId;
+            configFile.Save();
+            _logger.LogInfo("Client ID saved to config file");
+        }
+
+        private async Task InitWithClientIdAsync()
+        {
+            _bridge = new SpotifyBridge(_clientId, _dataPath, _logger);
+            _registry = new SpotifySongRegistry(_context, ModuleId);
+
+            InitOAuthManager();
+            SubscribePlaybackEvents();
+
+            // 加载已保存的 session
+            _bridge.LoadSession();
+
+            if (_bridge.IsLoggedIn)
+            {
+                // 尝试刷新 token 并加载歌单
+                if (await _bridge.EnsureTokenValidAsync())
+                {
+                    var user = await _bridge.GetCurrentUserAsync();
+                    if (user != null)
+                    {
+                        _bridge.Session.UserId = user.Id;
+                        _bridge.Session.DisplayName = user.DisplayName;
+                        _bridge.Session.Product = user.Product;
+                        _bridge.SaveSession();
+
+                        _logger.LogInfo($"Spotify logged in as {user.DisplayName} ({user.Product})");
+
+                        if (!_bridge.Session.IsPremium)
+                            _logger.LogWarning("Spotify Free account - playback control requires Premium");
+
+                        await LoadPlaylistsAsync();
+                        OnReadyStateChanged?.Invoke(true);
+                        return;
+                    }
+                }
+
+                _logger.LogWarning("Spotify session expired, clearing");
+                _bridge.ClearSession();
+            }
+
+            // 未登录，显示登录歌曲
+            _registry.RegisterLoginSong("点击播放以登录 Spotify");
+            OnReadyStateChanged?.Invoke(false);
+        }
+
+        public void OnEnable() { }
+
+        public void OnDisable() { }
+
+        public void OnUnload()
+        {
+            _pauseSubscription?.Dispose();
+            _oauthManager?.Dispose();
+            _bridge?.Dispose();
+            _spriteCache.Clear();
+            _savedCache.Clear();
+        }
+
+        // =====================================================================
+        // 配置
+        // =====================================================================
+
+        private void LoadConfig(string pluginPath)
+        {
+            // 直接读取 BepInEx 配置文件
+            var bepInExConfigPath = Path.Combine(pluginPath, "..", "..", "config", "com.chillpatcher.plugin.cfg");
+            var configFile = new ConfigFile(bepInExConfigPath, false);
+
+            _clientId = configFile.Bind(
+                $"Module:{ModuleId}",
+                "ClientId",
+                "YOUR_SPOTIFY_CLIENT_ID",
+                "Spotify Developer App Client ID.\n" +
+                "在 https://developer.spotify.com/dashboard 创建 App 获取。\n" +
+                "Redirect URI 设置为: fullstop://callback"
+            ).Value;
+
+            configFile.Save();
+        }
+
+        // =====================================================================
+        // OAuth
+        // =====================================================================
+
+        private void InitOAuthManager()
+        {
+            _oauthManager = new OAuthManager(_clientId, _dataPath, _logger);
+
+            _oauthManager.OnStatusChanged += (status) =>
+            {
+                _logger.LogInfo($"OAuth status: {status}");
+                _registry.UpdateLoginStatus(status);
+            };
+
+            _oauthManager.OnTokenReceived += async (tokenResponse) =>
+            {
+                _registry.UpdateLoginStatus("授权成功，正在获取用户信息...");
+                BringGameToForeground();
+
+                _bridge.SetTokens(tokenResponse);
+
+                // 获取用户信息
+                var user = await _bridge.GetCurrentUserAsync();
+                if (user != null)
+                {
+                    _bridge.Session.UserId = user.Id;
+                    _bridge.Session.DisplayName = user.DisplayName;
+                    _bridge.Session.Product = user.Product;
+                    _bridge.SaveSession();
+                    _logger.LogInfo($"Logged in as {user.DisplayName} ({user.Product})");
+                }
+
+                // 移除登录歌曲，加载歌单
+                _registry.UpdateLoginStatus("正在加载歌单...");
+                _registry.UnregisterLoginSong();
+                await LoadPlaylistsAsync();
+
+                _isLoggingIn = false;
+                OnReadyStateChanged?.Invoke(true);
+            };
+
+            _oauthManager.OnLoginFailed += (error) =>
+            {
+                _logger.LogError($"Login failed: {error}");
+                _registry.UpdateLoginStatus($"登录失败: {error}，再次播放以重试");
+                _isLoggingIn = false;
+                BringGameToForeground();
+            };
+        }
+
+        private void SubscribePlaybackEvents()
+        {
+            _pauseSubscription?.Dispose();
+            _pauseSubscription = _context.EventBus.Subscribe<PlayPausedEvent>(async e =>
+            {
+                // 只处理属于本模块的歌曲
+                if (e.Music == null || e.Music.ModuleId != ModuleId) return;
+                if (_bridge == null || !_bridge.IsLoggedIn || !_bridge.Session.IsPremium) return;
+
+                try
+                {
+                    if (e.IsPaused)
+                    {
+                        _logger.LogInfo("[Spotify] Game paused → pausing Spotify");
+                        await _bridge.PauseAsync();
+                    }
+                    else
+                    {
+                        _logger.LogInfo("[Spotify] Game resumed → resuming Spotify");
+                        await _bridge.ResumeAsync();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning($"[Spotify] Failed to sync pause state: {ex.Message}");
+                }
+            });
+            _logger.LogInfo("[Spotify] Subscribed to PlayPausedEvent");
+        }
+
+        // =====================================================================
+        // 歌单加载
+        // =====================================================================
+
+        private async Task LoadPlaylistsAsync()
+        {
+            try
+            {
+                // 加载 Liked Songs
+                _logger.LogInfo("Loading Liked Songs...");
+                var likedTracks = await _bridge.GetSavedTracksAsync(500);
+                if (likedTracks.Count > 0)
+                {
+                    _registry.RegisterLikedSongs(likedTracks);
+                    foreach (var t in likedTracks)
+                        _savedCache[t.Id] = true;
+                }
+
+                // 加载用户歌单
+                _logger.LogInfo("Loading playlists...");
+                var playlists = await _bridge.GetUserPlaylistsAsync();
+                foreach (var playlist in playlists)
+                {
+                    try
+                    {
+                        var tracks = await _bridge.GetPlaylistTracksAsync(playlist.Id);
+                        if (tracks.Count > 0)
+                            _registry.RegisterPlaylist(playlist, tracks);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning($"Failed to load playlist '{playlist.Name}': {ex.Message}");
+                    }
+                }
+
+                _logger.LogInfo($"Loaded {playlists.Count} playlists");
+
+                // 加载可用设备
+                await RefreshDevicesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to load playlists: {ex.Message}");
+            }
+        }
+
+        private async Task RefreshDevicesAsync()
+        {
+            try
+            {
+                var devices = await _bridge.GetAvailableDevicesAsync();
+                _logger.LogInfo($"[Spotify] Found {devices.Count} devices");
+
+                // 自动选中活跃设备
+                if (devices.Count > 0)
+                {
+                    var active = devices.Find(d => d.IsActive);
+                    if (active != null)
+                    {
+                        _activeDeviceId = active.Id;
+                        _activeDeviceName = active.Name;
+                    }
+                    else if (string.IsNullOrEmpty(_activeDeviceId))
+                    {
+                        // 没有活跃设备，选第一个
+                        _activeDeviceId = devices[0].Id;
+                        _activeDeviceName = devices[0].Name;
+                    }
+                }
+
+                // 注册/更新设备选择歌曲
+                _registry.RegisterDeviceSelector(_activeDeviceName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"[Spotify] Failed to load devices: {ex.Message}");
+                _registry.RegisterDeviceSelector(null);
+            }
+        }
+
+        private void ShowDeviceSelector()
+        {
+            _ = ShowDeviceSelectorAsync();
+        }
+
+        private async Task ShowDeviceSelectorAsync()
+        {
+            var devices = await _bridge.GetAvailableDevicesAsync();
+            _logger.LogInfo($"[Spotify] Showing device selector, {devices.Count} devices");
+
+            SpotifyDeviceWindow.Show(
+                devices,
+                _activeDeviceId,
+                onSelect: async (device) =>
+                {
+                    _logger.LogInfo($"[Spotify] User selected device: {device.Name} ({device.Id})");
+                    _activeDeviceId = device.Id;
+                    _activeDeviceName = device.Name;
+
+                    var success = await _bridge.TransferPlaybackAsync(device.Id, play: false);
+                    if (success)
+                        _logger.LogInfo($"[Spotify] Transferred playback to: {device.Name}");
+                    else
+                        _logger.LogWarning($"[Spotify] Failed to transfer to: {device.Name}");
+
+                    _registry.UpdateDeviceStatus(device.Name);
+                },
+                onCancel: () =>
+                {
+                    _logger.LogInfo("[Spotify] Device selection cancelled");
+                }
+            );
+        }
+
+        // =====================================================================
+        // IStreamingMusicSourceProvider
+        // =====================================================================
+
+        public Task<List<MusicInfo>> GetMusicListAsync()
+        {
+            var all = _context.MusicRegistry.GetMusicByModule(ModuleId);
+            return Task.FromResult(all?.ToList() ?? new List<MusicInfo>());
+        }
+
+        public Task<AudioClip> LoadAudioAsync(string uuid) => Task.FromResult<AudioClip>(null);
+
+        public Task<AudioClip> LoadAudioAsync(string uuid, CancellationToken token) => Task.FromResult<AudioClip>(null);
+
+        public void UnloadAudio(string uuid) { }
+
+        public async Task RefreshAsync()
+        {
+            if (!_bridge.IsLoggedIn) return;
+
+            _registry.UnregisterAll();
+            _savedCache.Clear();
+            await LoadPlaylistsAsync();
+        }
+
+        // =====================================================================
+        // IPlayableSourceResolver (Spotify Connect 播放)
+        // =====================================================================
+
+        public async Task<PlayableSource> ResolveAsync(string uuid, AudioQuality quality = AudioQuality.ExHigh, CancellationToken cancellationToken = default)
+        {
+            _logger.LogInfo($"[Spotify] ResolveAsync called: uuid={uuid}");
+
+            // 登录歌曲：触发配置或 OAuth 流程
+            if (uuid == SpotifySongRegistry.UUID_LOGIN)
+            {
+                if (!_isLoggingIn)
+                {
+                    _isLoggingIn = true;
+
+                    if (_needsClientId)
+                    {
+                        // Client ID 未配置，弹出配置窗口
+                        _registry.UpdateLoginStatus("请在弹出窗口中输入 Client ID");
+                        ShowConfigWindow();
+                    }
+                    else
+                    {
+                        // Client ID 已配置，启动 OAuth 登录
+                        _ = Task.Run(() => _oauthManager.StartLoginAsync(cancellationToken));
+                    }
+                }
+
+                return PlayableSource.FromPcmStream(uuid, new SilentPcmReader(120f), AudioFormat.Mp3);
+            }
+
+            // 设备选择：弹出设备选择窗口
+            if (uuid == SpotifySongRegistry.UUID_DEVICE_SELECT)
+            {
+                _logger.LogInfo("[Spotify] Device selector triggered");
+                ShowDeviceSelector();
+                return PlayableSource.FromPcmStream(uuid, new SilentPcmReader(30f), AudioFormat.Mp3);
+            }
+
+            // 常规歌曲：通过 Spotify Connect 播放
+            var music = _context.MusicRegistry.GetMusic(uuid);
+            if (music == null)
+            {
+                _logger.LogWarning($"[Spotify] Music not found: {uuid}");
+                return null;
+            }
+
+            var meta = GetTrackMeta(music);
+            if (meta == null || string.IsNullOrEmpty(meta.SpotifyUri))
+            {
+                _logger.LogWarning($"[Spotify] No Spotify URI for: {music.Title}");
+                return null;
+            }
+
+            if (!_bridge.Session.IsPremium)
+            {
+                _logger.LogWarning("[Spotify] Playback control requires Spotify Premium");
+                return PlayableSource.FromPcmStream(uuid, new SilentPcmReader(music.Duration), AudioFormat.Mp3);
+            }
+
+            // 如果没有选定设备，尝试自动检测
+            if (string.IsNullOrEmpty(_activeDeviceId))
+            {
+                var devices = await _bridge.GetAvailableDevicesAsync();
+                var active = devices.Find(d => d.IsActive);
+                if (active != null)
+                {
+                    _activeDeviceId = active.Id;
+                    _logger.LogInfo($"[Spotify] Auto-detected active device: {active.Name}");
+                }
+                else if (devices.Count > 0)
+                {
+                    _activeDeviceId = devices[0].Id;
+                    _logger.LogInfo($"[Spotify] Using first available device: {devices[0].Name}");
+                    await _bridge.TransferPlaybackAsync(_activeDeviceId, play: false);
+                }
+                else
+                {
+                    _logger.LogWarning("[Spotify] No Spotify devices found. Please open Spotify and select a device.");
+                    return null;
+                }
+            }
+
+            _logger.LogInfo($"[Spotify] Playing: {music.Title} on device {_activeDeviceId}");
+            var playSuccess = await _bridge.PlayTrackAsync(meta.SpotifyUri, _activeDeviceId);
+            if (playSuccess)
+                _logger.LogInfo($"[Spotify] Playback started: {music.Title}");
+            else
+                _logger.LogWarning($"[Spotify] Failed to start playback: {music.Title}");
+
+            // 返回静默 PCM（音频由 Spotify 客户端播放）
+            return PlayableSource.FromPcmStream(uuid, new SilentPcmReader(music.Duration), AudioFormat.Mp3);
+        }
+
+        public Task<PlayableSource> RefreshUrlAsync(string uuid, AudioQuality quality = AudioQuality.ExHigh, CancellationToken cancellationToken = default)
+        {
+            return ResolveAsync(uuid, quality, cancellationToken);
+        }
+
+        // =====================================================================
+        // ICoverProvider
+        // =====================================================================
+
+        public async Task<Sprite> GetMusicCoverAsync(string uuid)
+        {
+            if (uuid == SpotifySongRegistry.UUID_LOGIN)
+                return _context.DefaultCover.DefaultMusicCover;
+
+            var music = _context.MusicRegistry.GetMusic(uuid);
+            if (music == null) return _context.DefaultCover.DefaultMusicCover;
+
+            var meta = GetTrackMeta(music);
+            if (meta == null || string.IsNullOrEmpty(meta.CoverUrl))
+                return _context.DefaultCover.DefaultMusicCover;
+
+            return await DownloadSpriteAsync(meta.CoverUrl) ?? _context.DefaultCover.DefaultMusicCover;
+        }
+
+        public async Task<Sprite> GetAlbumCoverAsync(string albumId)
+        {
+            var album = _context.AlbumRegistry.GetAlbum(albumId);
+            if (album?.ExtendedData is string coverUrl && !string.IsNullOrEmpty(coverUrl))
+                return await DownloadSpriteAsync(coverUrl) ?? _context.DefaultCover.DefaultAlbumCover;
+
+            return _context.DefaultCover.DefaultAlbumCover;
+        }
+
+        public async Task<(byte[] data, string mimeType)> GetMusicCoverBytesAsync(string uuid)
+        {
+            var music = _context.MusicRegistry.GetMusic(uuid);
+            var meta = GetTrackMeta(music);
+            if (meta == null || string.IsNullOrEmpty(meta.CoverUrl))
+                return (null, null);
+
+            try
+            {
+                var request = UnityWebRequest.Get(meta.CoverUrl);
+                var op = request.SendWebRequest();
+                while (!op.isDone) await Task.Delay(50);
+
+                if (request.result != UnityWebRequest.Result.Success)
+                    return (null, null);
+
+                return (request.downloadHandler.data, "image/jpeg");
+            }
+            catch
+            {
+                return (null, null);
+            }
+        }
+
+        public void RemoveMusicCoverCache(string uuid) { }
+        public void RemoveAlbumCoverCache(string albumId) { }
+        public void ClearCache() => _spriteCache.Clear();
+
+        private async Task<Sprite> DownloadSpriteAsync(string url)
+        {
+            if (string.IsNullOrEmpty(url)) return null;
+            if (_spriteCache.TryGetValue(url, out var cached)) return cached;
+
+            try
+            {
+                var request = UnityWebRequestTexture.GetTexture(url);
+                var op = request.SendWebRequest();
+                while (!op.isDone) await Task.Delay(50);
+
+                if (request.result != UnityWebRequest.Result.Success)
+                    return null;
+
+                var texture = DownloadHandlerTexture.GetContent(request);
+
+                // 中心裁剪为正方形（与 Bilibili 模块一致）
+                int size = Mathf.Min(texture.width, texture.height);
+                int offsetX = (texture.width - size) / 2;
+                int offsetY = (texture.height - size) / 2;
+                var rect = new Rect(offsetX, offsetY, size, size);
+                var pivot = new Vector2(0.5f, 0.5f);
+
+                var sprite = Sprite.Create(texture, rect, pivot);
+                _spriteCache[url] = sprite;
+                return sprite;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to download cover: {ex.Message}");
+                return null;
+            }
+        }
+
+        // =====================================================================
+        // IFavoriteExcludeHandler — 收藏持久化在 Spotify 服务端
+        // =====================================================================
+
+        public bool IsFavorite(string uuid)
+        {
+            var meta = GetTrackMetaByUuid(uuid);
+            if (meta == null) return false;
+            return _savedCache.TryGetValue(meta.SpotifyId, out var saved) && saved;
+        }
+
+        public async void SetFavorite(string uuid, bool isFavorite)
+        {
+            var meta = GetTrackMetaByUuid(uuid);
+            if (meta == null || _bridge == null || !_bridge.IsLoggedIn) return;
+
+            bool success;
+            if (isFavorite)
+                success = await _bridge.SaveTracksAsync(new List<string> { meta.SpotifyId });
+            else
+                success = await _bridge.RemoveTracksAsync(new List<string> { meta.SpotifyId });
+
+            if (success)
+            {
+                _savedCache[meta.SpotifyId] = isFavorite;
+                var music = _context.MusicRegistry.GetMusic(uuid);
+                if (music != null) music.IsFavorite = isFavorite;
+                _logger.LogInfo($"[Spotify] Favorite {(isFavorite ? "saved" : "removed")}: {music?.Title}");
+            }
+            else
+            {
+                _logger.LogWarning($"[Spotify] Failed to {(isFavorite ? "save" : "remove")} favorite: {uuid}");
+            }
+        }
+
+        public bool IsExcluded(string uuid) => false;
+        public void SetExcluded(string uuid, bool isExcluded) { }
+
+        public IReadOnlyList<string> GetFavorites()
+        {
+            var result = new List<string>();
+            foreach (var kvp in _savedCache)
+            {
+                if (!kvp.Value) continue;
+                var uuid = MusicInfo.GenerateUUID($"spotify_{kvp.Key}");
+                result.Add(uuid);
+            }
+            return result;
+        }
+
+        public IReadOnlyList<string> GetExcluded() => new List<string>();
+
+        // =====================================================================
+        // 辅助方法
+        // =====================================================================
+
+        private SpotifyTrackMeta GetTrackMeta(MusicInfo music)
+        {
+            if (music?.ExtendedData == null) return null;
+
+            if (music.ExtendedData is SpotifyTrackMeta meta)
+                return meta;
+
+            // 可能从 JSON 反序列化为 JObject
+            try
+            {
+                return JsonConvert.DeserializeObject<SpotifyTrackMeta>(
+                    JsonConvert.SerializeObject(music.ExtendedData));
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private SpotifyTrackMeta GetTrackMetaByUuid(string uuid)
+        {
+            var music = _context.MusicRegistry.GetMusic(uuid);
+            return GetTrackMeta(music);
+        }
+
+        /// <summary>
+        /// 将游戏窗口拉回前台（OAuth 完成后从浏览器切回）。
+        /// </summary>
+        private void BringGameToForeground()
+        {
+            try
+            {
+                var pid = GetCurrentProcessId();
+                IntPtr gameWindow = IntPtr.Zero;
+
+                EnumWindows((hWnd, lParam) =>
+                {
+                    GetWindowThreadProcessId(hWnd, out uint windowPid);
+                    if (windowPid == pid && IsWindowVisible(hWnd))
+                    {
+                        gameWindow = hWnd;
+                        return false; // 找到第一个可见窗口就停止
+                    }
+                    return true;
+                }, IntPtr.Zero);
+
+                if (gameWindow != IntPtr.Zero)
+                {
+                    SetForegroundWindow(gameWindow);
+                    _logger.LogInfo("Game window brought to foreground");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to bring game to foreground: {ex.Message}");
+            }
+        }
+    }
+}

--- a/ChillPatcher.Module.Spotify/SpotifySongRegistry.cs
+++ b/ChillPatcher.Module.Spotify/SpotifySongRegistry.cs
@@ -1,0 +1,249 @@
+using System.Collections.Generic;
+using BepInEx.Logging;
+using ChillPatcher.SDK.Interfaces;
+using ChillPatcher.SDK.Models;
+
+namespace ChillPatcher.Module.Spotify
+{
+    /// <summary>
+    /// 歌曲/专辑/标签注册辅助类，负责将 Spotify 数据注册到 ChillPatcher 注册表中。
+    /// </summary>
+    public class SpotifySongRegistry
+    {
+        public const string TAG_LOGIN = "spotify_login_tag";
+        public const string ALBUM_LOGIN = "spotify_login_album";
+        public const string UUID_LOGIN = "spotify_login_action";
+        public const string TAG_LIKED = "spotify_liked_songs";
+        public const string ALBUM_LIKED = "spotify_liked_album";
+        public const string TAG_DEVICES = "spotify_devices_tag";
+        public const string ALBUM_DEVICES = "spotify_devices_album";
+        public const string UUID_DEVICE_SELECT = "spotify_device_select";
+
+        private readonly IModuleContext _context;
+        private readonly string _moduleId;
+        private readonly ManualLogSource _logger;
+
+        public SpotifySongRegistry(IModuleContext context, string moduleId)
+        {
+            _context = context;
+            _moduleId = moduleId;
+            _logger = context.Logger;
+        }
+
+        // =====================================================================
+        // 登录歌曲（触发 OAuth 流程）
+        // =====================================================================
+
+        public void RegisterLoginSong(string statusText)
+        {
+            _context.TagRegistry.RegisterTag(TAG_LOGIN, "Spotify 登录", _moduleId);
+
+            _context.AlbumRegistry.RegisterAlbum(new AlbumInfo
+            {
+                AlbumId = ALBUM_LOGIN,
+                DisplayName = "Spotify 登录",
+                Artist = "ChillPatcher",
+                TagId = TAG_LOGIN,
+                ModuleId = _moduleId,
+                SortOrder = 0
+            }, _moduleId);
+
+            _context.MusicRegistry.RegisterMusic(new MusicInfo
+            {
+                UUID = UUID_LOGIN,
+                Title = "Spotify 登录",
+                Artist = statusText,
+                AlbumId = ALBUM_LOGIN,
+                TagId = TAG_LOGIN,
+                SourceType = MusicSourceType.Stream,
+                SourcePath = "login_trigger",
+                Duration = 120f,
+                ModuleId = _moduleId,
+                IsUnlocked = true
+            }, _moduleId);
+        }
+
+        public void UnregisterLoginSong()
+        {
+            _context.MusicRegistry.UnregisterMusic(UUID_LOGIN);
+            _context.AlbumRegistry.UnregisterAlbum(ALBUM_LOGIN);
+            _context.TagRegistry.UnregisterTag(TAG_LOGIN);
+        }
+
+        public void UpdateLoginStatus(string statusText)
+        {
+            var music = _context.MusicRegistry.GetMusic(UUID_LOGIN);
+            if (music != null)
+            {
+                music.Artist = statusText;
+            }
+        }
+
+        // =====================================================================
+        // Liked Songs（用户收藏）
+        // =====================================================================
+
+        public void RegisterLikedSongs(List<SpotifyTrack> tracks)
+        {
+            _context.TagRegistry.RegisterTag(TAG_LIKED, "Liked Songs", _moduleId);
+
+            _context.AlbumRegistry.RegisterAlbum(new AlbumInfo
+            {
+                AlbumId = ALBUM_LIKED,
+                DisplayName = "Liked Songs",
+                Artist = "Spotify",
+                TagId = TAG_LIKED,
+                ModuleId = _moduleId,
+                SortOrder = 0,
+                SongCount = tracks.Count
+            }, _moduleId);
+
+            RegisterTracks(tracks, TAG_LIKED, ALBUM_LIKED);
+        }
+
+        // =====================================================================
+        // 歌单注册
+        // =====================================================================
+
+        public void RegisterPlaylist(SpotifyPlaylist playlist, List<SpotifyTrack> tracks)
+        {
+            var tagId = $"spotify_playlist_{playlist.Id}";
+            var albumId = $"spotify_album_{playlist.Id}";
+
+            _context.TagRegistry.RegisterTag(tagId, playlist.Name, _moduleId);
+
+            _context.AlbumRegistry.RegisterAlbum(new AlbumInfo
+            {
+                AlbumId = albumId,
+                DisplayName = playlist.Name,
+                Artist = playlist.Owner?.DisplayName ?? "Spotify",
+                TagId = tagId,
+                ModuleId = _moduleId,
+                SongCount = tracks.Count,
+                // 歌单封面 URL 存入 ExtendedData
+                ExtendedData = playlist.BestCoverUrl
+            }, _moduleId);
+
+            RegisterTracks(tracks, tagId, albumId);
+        }
+
+        // =====================================================================
+        // 曲目注册
+        // =====================================================================
+
+        private void RegisterTracks(List<SpotifyTrack> tracks, string tagId, string albumId)
+        {
+            var musicList = new List<MusicInfo>();
+
+            foreach (var track in tracks)
+            {
+                var uuid = MusicInfo.GenerateUUID($"spotify_{track.Id}");
+                musicList.Add(new MusicInfo
+                {
+                    UUID = uuid,
+                    Title = track.Name,
+                    Artist = track.ArtistName,
+                    AlbumId = albumId,
+                    TagId = tagId,
+                    SourceType = MusicSourceType.Stream,
+                    SourcePath = track.Uri,  // spotify:track:xxx，用于 Connect 播放
+                    Duration = track.DurationSeconds,
+                    ModuleId = _moduleId,
+                    IsUnlocked = true,
+                    // ExtendedData 存储 track 元数据供封面和收藏使用
+                    ExtendedData = new SpotifyTrackMeta
+                    {
+                        SpotifyId = track.Id,
+                        SpotifyUri = track.Uri,
+                        CoverUrl = track.BestCoverUrl
+                    }
+                });
+            }
+
+            _context.MusicRegistry.RegisterMusicBatch(musicList, _moduleId);
+            _logger.LogInfo($"Registered {musicList.Count} tracks for [{tagId}]");
+        }
+
+        // =====================================================================
+        // 设备列表
+        // =====================================================================
+
+        /// <summary>
+        /// 注册"选择设备"歌曲（单首，点击弹窗）。
+        /// </summary>
+        public void RegisterDeviceSelector(string currentDeviceName = null)
+        {
+            UnregisterDeviceSelector();
+
+            _context.TagRegistry.RegisterTag(TAG_DEVICES, "Spotify 设备", _moduleId);
+
+            _context.AlbumRegistry.RegisterAlbum(new AlbumInfo
+            {
+                AlbumId = ALBUM_DEVICES,
+                DisplayName = "Spotify 设备",
+                Artist = "Spotify",
+                TagId = TAG_DEVICES,
+                ModuleId = _moduleId,
+                SortOrder = -1
+            }, _moduleId);
+
+            var statusText = string.IsNullOrEmpty(currentDeviceName)
+                ? ">>> 点击选择播放设备 <<<"
+                : $"当前: {currentDeviceName}  (点击切换)";
+
+            _context.MusicRegistry.RegisterMusic(new MusicInfo
+            {
+                UUID = UUID_DEVICE_SELECT,
+                Title = "选择播放设备",
+                Artist = statusText,
+                AlbumId = ALBUM_DEVICES,
+                TagId = TAG_DEVICES,
+                SourceType = MusicSourceType.Stream,
+                SourcePath = "device_select",
+                Duration = 10f,
+                ModuleId = _moduleId,
+                IsUnlocked = true
+            }, _moduleId);
+        }
+
+        public void UpdateDeviceStatus(string deviceName)
+        {
+            var music = _context.MusicRegistry.GetMusic(UUID_DEVICE_SELECT);
+            if (music != null)
+            {
+                music.Artist = string.IsNullOrEmpty(deviceName)
+                    ? ">>> 点击选择播放设备 <<<"
+                    : $"当前: {deviceName}  (点击切换)";
+            }
+        }
+
+        public void UnregisterDeviceSelector()
+        {
+            _context.MusicRegistry.UnregisterMusic(UUID_DEVICE_SELECT);
+            _context.AlbumRegistry.UnregisterAlbum(ALBUM_DEVICES);
+            _context.TagRegistry.UnregisterTag(TAG_DEVICES);
+        }
+
+        // =====================================================================
+        // 清理
+        // =====================================================================
+
+        public void UnregisterAll()
+        {
+            _context.MusicRegistry.UnregisterAllByModule(_moduleId);
+            _context.AlbumRegistry.UnregisterAllByModule(_moduleId);
+            _context.TagRegistry.UnregisterAllByModule(_moduleId);
+        }
+    }
+
+    /// <summary>
+    /// 存储在 MusicInfo.ExtendedData 中的 Spotify 元数据。
+    /// </summary>
+    public class SpotifyTrackMeta
+    {
+        public string SpotifyId { get; set; }
+        public string SpotifyUri { get; set; }
+        public string CoverUrl { get; set; }
+    }
+
+}

--- a/Patches/SystemMediaTransport_Patches.cs
+++ b/Patches/SystemMediaTransport_Patches.cs
@@ -3,6 +3,9 @@ using Bulbul;
 using System;
 using R3;
 using ChillPatcher.UIFramework.Audio;
+using ChillPatcher.ModuleSystem;
+using ChillPatcher.SDK.Events;
+using ChillPatcher.Patches.UIFramework;
 
 namespace ChillPatcher.Patches
 {
@@ -88,15 +91,16 @@ namespace ChillPatcher.Patches
         {
             try
             {
-                if (!PluginConfig.EnableSystemMediaTransport.Value)
-                    return;
-                    
-                SystemMediaTransportService.Instance.SetPlaybackStatus(false);
+                if (PluginConfig.EnableSystemMediaTransport.Value)
+                    SystemMediaTransportService.Instance.SetPlaybackStatus(false);
             }
             catch (Exception ex)
             {
                 Plugin.Log.LogError($"[SMTC] PauseMusic 异常: {ex.Message}");
             }
+
+            // 通知模块（如 Spotify Connect）暂停
+            PublishPlayPausedEvent(true);
         }
 
         /// <summary>
@@ -108,14 +112,40 @@ namespace ChillPatcher.Patches
         {
             try
             {
-                if (!PluginConfig.EnableSystemMediaTransport.Value)
-                    return;
-                    
-                SystemMediaTransportService.Instance.SetPlaybackStatus(true);
+                if (PluginConfig.EnableSystemMediaTransport.Value)
+                    SystemMediaTransportService.Instance.SetPlaybackStatus(true);
             }
             catch (Exception ex)
             {
                 Plugin.Log.LogError($"[SMTC] UnPauseMusic 异常: {ex.Message}");
+            }
+
+            // 通知模块（如 Spotify Connect）恢复播放
+            PublishPlayPausedEvent(false);
+        }
+
+        private static void PublishPlayPausedEvent(bool isPaused)
+        {
+            try
+            {
+                var eventBus = EventBus.Instance;
+                if (eventBus == null) return;
+
+                var musicService = MusicService_RemoveLimit_Patch.CurrentInstance;
+                var playingUuid = musicService?.PlayingMusic?.UUID;
+                var musicInfo = !string.IsNullOrEmpty(playingUuid)
+                    ? ModuleSystem.Registry.MusicRegistry.Instance?.GetMusic(playingUuid)
+                    : null;
+
+                eventBus.Publish(new PlayPausedEvent
+                {
+                    Music = musicInfo,
+                    IsPaused = isPaused
+                });
+            }
+            catch (Exception ex)
+            {
+                Plugin.Log.LogError($"[SMTC] PublishPlayPausedEvent 异常: {ex.Message}");
             }
         }
     }


### PR DESCRIPTION
新增模块 ChillPatcher.Module.Spotify (com.chillpatcher.spotify):
- Spotify Connect 播放控制（音频通过 Spotify 客户端播放）
- OAuth 2.0 PKCE 认证，使用 fullstop:// 自定义 URI 协议
- 歌单和 Liked Songs 同步
- 设备选择弹窗（圆角半透明，贴近游戏 UI 风格）
- 专辑封面加载
- 收藏功能（持久化在 Spotify 服务端）
- 游戏暂停/恢复与 Spotify Connect 联动
- 配置窗口和设备窗口支持中/英/日三语
- Client ID 游戏内配置，无需手动编辑配置文件

主插件改动:
- PauseMusic/UnPauseMusic 补丁中发布 PlayPausedEvent 使模块可以响应播放状态变化

<img width="1920" height="1080" alt="Spotify-chill-with-you" src="https://github.com/user-attachments/assets/8c96efe0-fc34-4357-b298-761c1ac9bf0a" />

这个功能需要到Spotify Developer Dashboard创建应用，获取ClientID，之后填入后调度WebApi来完成播放，对于相关的能力已经正确声明。
