### PR TITLE
feat(audio): add configurable peak threshold for audio detection

### DIFF
--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -66,6 +66,7 @@ namespace ChillPatcher
         public static ConfigEntry<float> AudioDetectionInterval { get; private set; }
         public static ConfigEntry<float> AudioResumeFadeInDuration { get; private set; }
         public static ConfigEntry<float> AudioMuteFadeOutDuration { get; private set; }
+        public static ConfigEntry<float> AudioPeakThreshold { get; private set; }
 
         // 系统媒体控制设置
         public static ConfigEntry<bool> EnableSystemMediaTransport { get; private set; }
@@ -358,6 +359,20 @@ namespace ChillPatcher
                     "当检测到其他音频时，游戏音乐会在此时间内逐渐降低音量\n" +
                     "默认：0.3秒（快速响应）",
                     new AcceptableValueRange<float>(0f, 3f)
+                )
+            );
+
+            AudioPeakThreshold = config.Bind(
+                "Audio",
+                "AudioPeakThreshold",
+                0.001f,
+                new ConfigDescription(
+                    "音频检测音量阈值（0-1）\n" +
+                    "低于此阈值的音频信号将被忽略，不会触发降低音量\n" +
+                    "默认：0.001（极低阈值，几乎任何声音都会触发）\n" +
+                    "较高值：可忽略轻微的背景噪音\n" +
+                    "建议范围：0.001-0.1",
+                    new AcceptableValueRange<float>(0f, 1f)
                 )
             );
 

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -67,6 +67,7 @@ namespace ChillPatcher
         public static ConfigEntry<float> AudioResumeFadeInDuration { get; private set; }
         public static ConfigEntry<float> AudioMuteFadeOutDuration { get; private set; }
         public static ConfigEntry<float> AudioPeakThreshold { get; private set; }
+        public static ConfigEntry<string> AudioExcludedProcesses { get; private set; }
 
         // 系统媒体控制设置
         public static ConfigEntry<bool> EnableSystemMediaTransport { get; private set; }
@@ -374,6 +375,16 @@ namespace ChillPatcher
                     "建议范围：0.001-0.1",
                     new AcceptableValueRange<float>(0f, 1f)
                 )
+            );
+
+            AudioExcludedProcesses = config.Bind(
+                "Audio",
+                "AudioExcludedProcesses",
+                "",
+                "音频检测排除的进程文件名列表（逗号分隔，不区分大小写，含扩展名）\n" +
+                "这些进程的音频会话将被忽略，不会触发降低音量\n" +
+                "典型用途：排除远程桌面音频转发避免反馈环\n" +
+                "示例：parsecd.exe"
             );
 
             // npm/esbuild 构建开关

--- a/UIFramework/Audio/SystemAudioMonitor.cs
+++ b/UIFramework/Audio/SystemAudioMonitor.cs
@@ -33,6 +33,7 @@ namespace ChillPatcher.UIFramework.Audio
         private float _detectionInterval;
         private float _fadeInDuration;
         private float _fadeOutDuration;
+        private float _peakThreshold;
 
         // AudioMixer 引用
         private AudioMixer _musicMixer;
@@ -66,6 +67,7 @@ namespace ChillPatcher.UIFramework.Audio
             _detectionInterval = PluginConfig.AudioDetectionInterval.Value;
             _fadeInDuration = PluginConfig.AudioResumeFadeInDuration.Value;
             _fadeOutDuration = PluginConfig.AudioMuteFadeOutDuration.Value;
+            _peakThreshold = PluginConfig.AudioPeakThreshold.Value;
 
             // 获取初始音量
             if (_musicMixer != null && _musicMixer.GetFloat("MusicVolume", out float vol))
@@ -92,6 +94,7 @@ namespace ChillPatcher.UIFramework.Audio
             _detectionInterval = PluginConfig.AudioDetectionInterval.Value;
             _fadeInDuration = PluginConfig.AudioResumeFadeInDuration.Value;
             _fadeOutDuration = PluginConfig.AudioMuteFadeOutDuration.Value;
+            _peakThreshold = PluginConfig.AudioPeakThreshold.Value;
 
             Start();
         }
@@ -183,7 +186,7 @@ namespace ChillPatcher.UIFramework.Audio
                         {
                             // 检查是否真的有声音（峰值电平 > 0）
                             float peakValue = session.AudioMeterInformation.MasterPeakValue;
-                            if (peakValue > 0.001f) // 有实际音频输出
+                            if (peakValue > _peakThreshold) // 超过检测阈值
                             {
                                 return true;
                             }

--- a/UIFramework/Audio/SystemAudioMonitor.cs
+++ b/UIFramework/Audio/SystemAudioMonitor.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NAudio.CoreAudioApi;
@@ -34,6 +38,7 @@ namespace ChillPatcher.UIFramework.Audio
         private float _fadeInDuration;
         private float _fadeOutDuration;
         private float _peakThreshold;
+        private HashSet<string> _excludedProcessNames;
 
         // AudioMixer 引用
         private AudioMixer _musicMixer;
@@ -68,6 +73,7 @@ namespace ChillPatcher.UIFramework.Audio
             _fadeInDuration = PluginConfig.AudioResumeFadeInDuration.Value;
             _fadeOutDuration = PluginConfig.AudioMuteFadeOutDuration.Value;
             _peakThreshold = PluginConfig.AudioPeakThreshold.Value;
+            _excludedProcessNames = ParseExcludedProcesses(PluginConfig.AudioExcludedProcesses.Value);
 
             // 获取初始音量
             if (_musicMixer != null && _musicMixer.GetFloat("MusicVolume", out float vol))
@@ -95,6 +101,7 @@ namespace ChillPatcher.UIFramework.Audio
             _fadeInDuration = PluginConfig.AudioResumeFadeInDuration.Value;
             _fadeOutDuration = PluginConfig.AudioMuteFadeOutDuration.Value;
             _peakThreshold = PluginConfig.AudioPeakThreshold.Value;
+            _excludedProcessNames = ParseExcludedProcesses(PluginConfig.AudioExcludedProcesses.Value);
 
             Start();
         }
@@ -105,12 +112,12 @@ namespace ChillPatcher.UIFramework.Audio
         public void Start()
         {
             if (_isRunning) return;
-            
+
             _cts = new CancellationTokenSource();
             _isRunning = true;
             _monitorTask = Task.Run(() => MonitorLoop(_cts.Token));
-            
-            _log.LogInfo($"系统音频监控已启动 (检测间隔: {_detectionInterval}秒, 目标音量: {_targetVolume})");
+
+            _log.LogInfo($"系统音频监控已启动 (检测间隔: {_detectionInterval}秒, 目标音量: {_targetVolume}, 排除进程: [{string.Join(",", _excludedProcessNames)}])");
         }
 
         /// <summary>
@@ -119,13 +126,13 @@ namespace ChillPatcher.UIFramework.Audio
         public void Stop()
         {
             if (!_isRunning) return;
-            
+
             _cts?.Cancel();
             _isRunning = false;
-            
+
             // 恢复音量
             _currentVolumeMultiplier = 1f;
-            
+
             _log.LogInfo("系统音频监控已停止");
         }
 
@@ -139,7 +146,7 @@ namespace ChillPatcher.UIFramework.Audio
                 while (!token.IsCancellationRequested)
                 {
                     bool hasOtherAudio = CheckOtherAudioPlaying();
-                    
+
                     if (hasOtherAudio != _otherAudioPlaying)
                     {
                         _otherAudioPlaying = hasOtherAudio;
@@ -180,6 +187,14 @@ namespace ChillPatcher.UIFramework.Audio
                         uint processId = session.GetProcessID;
                         if (processId == _currentProcessId || processId == 0)
                             continue;
+
+                        // 跳过排除列表中的进程
+                        if (_excludedProcessNames.Count > 0)
+                        {
+                            var fileName = ResolveProcessFileName((int)processId, session);
+                            if (fileName != null && _excludedProcessNames.Contains(fileName))
+                                continue;
+                        }
 
                         // 检查会话状态
                         if (session.State == NAudio.CoreAudioApi.Interfaces.AudioSessionState.AudioSessionStateActive)
@@ -297,6 +312,96 @@ namespace ChillPatcher.UIFramework.Audio
         /// </summary>
         public bool IsRunning => _isRunning;
 
+        #region Process Name Resolution
+
+        private static HashSet<string> ParseExcludedProcesses(string config)
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(config)) return set;
+            foreach (var name in config.Split(','))
+            {
+                var trimmed = name.Trim();
+                if (trimmed.Length > 0) set.Add(trimmed);
+            }
+            return set;
+        }
+
+        /// <summary>
+        /// 解析进程文件名（含扩展名），三层 fallback:
+        /// 1. P/Invoke QueryFullProcessImageName（大部分进程可用）
+        /// 2. Process.GetProcesses() 快照 + ".exe"（NtQuerySystemInformation，不需要打开句柄）
+        /// 3. WASAPI session identifier 解析（从会话属性提取 exe 路径，适用于受保护的服务进程）
+        /// </summary>
+        private static string ResolveProcessFileName(int processId, NAudio.CoreAudioApi.AudioSessionControl session)
+        {
+            // 1. P/Invoke
+            var handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+            if (handle != IntPtr.Zero)
+            {
+                try
+                {
+                    var sb = new StringBuilder(1024);
+                    int size = sb.Capacity;
+                    if (QueryFullProcessImageName(handle, 0, sb, ref size))
+                        return Path.GetFileName(sb.ToString());
+                }
+                finally
+                {
+                    CloseHandle(handle);
+                }
+            }
+
+            // 2. GetProcesses fallback
+            try
+            {
+                foreach (var proc in Process.GetProcesses())
+                {
+                    try
+                    {
+                        if (proc.Id == processId)
+                            return proc.ProcessName + ".exe";
+                    }
+                    finally { proc.Dispose(); }
+                }
+            }
+            catch { }
+
+            // 3. WASAPI session identifier fallback
+            try
+            {
+                var sid = session.GetSessionIdentifier;
+                if (!string.IsNullOrEmpty(sid))
+                {
+                    int lastPipe = sid.LastIndexOf('|');
+                    if (lastPipe >= 0 && lastPipe < sid.Length - 1)
+                    {
+                        var exePath = sid.Substring(lastPipe + 1);
+                        // 截断 %b{...} 等后缀
+                        int pct = exePath.IndexOf('%');
+                        if (pct > 0) exePath = exePath.Substring(0, pct);
+                        if (exePath.IndexOf('\\') >= 0 || exePath.IndexOf('/') >= 0)
+                            return Path.GetFileName(exePath);
+                    }
+                }
+            }
+            catch { }
+
+            return null;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr OpenProcess(uint dwDesiredAccess, bool bInheritHandle, int dwProcessId);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool QueryFullProcessImageName(IntPtr hProcess, int dwFlags, StringBuilder lpExeName, ref int lpdwSize);
+
+        [DllImport("kernel32.dll")]
+        private static extern bool CloseHandle(IntPtr hObject);
+
+        private const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+
+        #endregion
+
         public void Dispose()
         {
             if (_disposed) return;
@@ -316,7 +421,7 @@ namespace ChillPatcher.UIFramework.Audio
         private static MainThreadDispatcher _instance;
         public static MainThreadDispatcher Instance => _instance;
 
-        private readonly System.Collections.Generic.Queue<Action> _executionQueue = 
+        private readonly System.Collections.Generic.Queue<Action> _executionQueue =
             new System.Collections.Generic.Queue<Action>();
 
         private static readonly object _lock = new object();


### PR DESCRIPTION
## Summary

- 将音频检测中硬编码的 `0.001f` 峰值阈值改为用户可配置的 `AudioPeakThreshold` 设置项
- 默认值 `0.001f` 保持向后兼容，用户可在 Audio 设置面板中自由调整
- 调高阈值可忽略轻微背景噪音，只在较大音量的外部音频播放时触发降低游戏音量
- 新增 `AudioExcludedProcesses` 配置项，支持按进程文件名排除特定音频会话，避免远程桌面等工具镜像游戏音频输出导致的检测反馈环

Closes #61

## Changes

| File | Change |
|------|--------|
| `PluginConfig.cs` | 新增 `AudioPeakThreshold` 配置项（范围 0-1，默认 0.001）；新增 `AudioExcludedProcesses` 配置项（逗号分隔的进程文件名，默认空） |
| `SystemAudioMonitor.cs` | 缓存配置值，替换硬编码阈值；新增三层进程名解析（P/Invoke → GetProcesses 快照 → WASAPI session identifier）排除指定进程的音频会话 |

## Test plan

- [x] 保持默认值 0.001，验证行为与改动前一致
- [x] 调高阈值（如 0.05），验证轻微背景音不再触发降音
- [x] 设为 0，验证任何音频都触发降音
- [x] 设为 1，验证不会触发降音
- [x] 确认设置面板中 Audio 分区正确展示新配置项
- [x] 配置 `parsecd.exe` 排除 Parsec，验证远程桌面连接时不再触发音量反馈环
- [x] 排除列表为空时，行为与改动前一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)