### PR TITLE
fix(ui): avoid NTFS junction resolution in UIInstance path detection

### DIFF
--- a/UIInstanceConfig.cs
+++ b/UIInstanceConfig.cs
@@ -102,14 +102,16 @@ namespace ChillPatcher
                 foreach (var dir in Directory.GetDirectories(uiBaseDir))
                 {
                     var dirName = Path.GetFileName(dir);
+                    // 使用 uiBaseDir + dirName 构造路径，避免 NTFS junction 未解析的路径被传入
+                    var dirPath = Path.Combine(uiBaseDir, dirName);
 
                     // 跳过没有入口文件或 package.json 的目录
-                    var hasEntry = File.Exists(Path.Combine(dir, "@outputs", "esbuild", "app.js"));
-                    var hasPkg = File.Exists(Path.Combine(dir, "package.json"));
+                    var hasEntry = File.Exists(Path.Combine(dirPath, "@outputs", "esbuild", "app.js"));
+                    var hasPkg = File.Exists(Path.Combine(dirPath, "package.json"));
                     if (!hasEntry && !hasPkg) continue;
 
                     var isDefault = dirName == "default";
-                    var entry = BindInstance(dirName, dir,
+                    var entry = BindInstance(dirName, dirPath,
                         defaultSortingOrder: isDefault ? 1000 : nextOrder,
                         defaultEnabled: true,
                         defaultInteractive: true);
@@ -176,8 +178,10 @@ namespace ChillPatcher
                 _log.LogInfo($"[UIInstanceConfig] 已覆盖默认值: UIInstance.{id} (sortOrder={defaultSortingOrder}, interactive={defaultInteractive})");
             }
 
-            // 从 config 读取实际值
-            entry.WorkingDir = entry.CfgWorkingDir.Value;
+            // WorkingDir 始终使用运行时检测的路径，不从 config 缓存读取
+            // 避免 NTFS junction 未解析的路径被持久化导致 IO 沙箱路径不匹配
+            entry.CfgWorkingDir.Value = workingDir;
+            entry.WorkingDir = workingDir;
             entry.Enabled = entry.CfgEnabled.Value;
             entry.SortingOrder = entry.CfgSortingOrder.Value;
             entry.Interactive = entry.CfgInteractive.Value;


### PR DESCRIPTION
## Summary

- 当游戏目录通过 NTFS junction 访问时（如 wallpaper engine 链接到 Steam 安装目录），`Directory.GetDirectories()` 返回未解析的 junction 路径，该路径通过 `ConfigFile.Bind()` 被缓存到 BepInEx 配置中
- 后续启动从配置缓存读取 WorkingDir 时，得到的是未解析的 junction 路径，与 OneJS IO sandbox 使用的真实路径不匹配，导致 UI 加载失败

## Changes

1. 使用 `Path.Combine(uiBaseDir, dirName)` 构造子目录路径，确保与运行时 `uiBaseDir` 一致
2. WorkingDir 始终使用运行时检测的路径写回配置，不依赖 BepInEx 配置缓存的历史值

## Test plan

- [x] 通过 wallpaper engine（junction 路径）启动游戏，确认 UI 正常加载
- [x] 通过 Steam（真实路径）启动游戏，确认 UI 正常加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)