### PR TITLE
feat(netease): add auth recovery, trial detection, and account UI

### DIFF
--- a/ChillPatcher.Module.Netease/NeteaseAccountApi.cs
+++ b/ChillPatcher.Module.Netease/NeteaseAccountApi.cs
@@ -1,0 +1,96 @@
+using System;
+using BepInEx.Logging;
+using ChillPatcher.SDK.Interfaces;
+using UnityEngine;
+
+namespace ChillPatcher.Module.Netease
+{
+    /// <summary>
+    /// 网易云账户 API：通过 chill.custom.get("netease_account") 访问
+    /// 前端 500ms 轮询属性获取登录状态、用户信息、二维码；按钮调用方法触发登录/登出/刷新
+    /// </summary>
+    public class NeteaseAccountApi : ICustomJSApi
+    {
+        public string Name => "netease_account";
+
+        private readonly NeteaseSessionManager _sessionManager;
+        private readonly ManualLogSource _logger;
+        private QRLoginManager _qrLoginManager;
+
+        private string _statusMessage = "";
+        private string _qrCodeBase64 = "";
+
+        public NeteaseAccountApi(NeteaseSessionManager sessionManager, ManualLogSource logger)
+        {
+            _sessionManager = sessionManager;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// 绑定 QRLoginManager，订阅状态和二维码更新事件
+        /// 因为 QRLoginManager 可能在 AccountApi 构造之后才创建，所以用 setter 注入
+        /// </summary>
+        public void SetQRLoginManager(QRLoginManager qrLoginManager)
+        {
+            _qrLoginManager = qrLoginManager;
+            _qrLoginManager.OnStatusChanged += msg => _statusMessage = msg ?? "";
+            _qrLoginManager.OnQRCodeUpdated += _ => SyncQRCode();
+
+            // 主动同步一次当前状态（QR 可能在绑定前已生成）
+            SyncQRCode();
+        }
+
+        private void SyncQRCode()
+        {
+            if (_qrLoginManager == null) return;
+            var bytes = _qrLoginManager.QRCodeBytes;
+            _qrCodeBase64 = bytes != null && bytes.Length > 0
+                ? Convert.ToBase64String(bytes)
+                : "";
+        }
+
+        #region Properties (read by JS UI via polling)
+
+        public string sessionState => _sessionManager.State switch
+        {
+            SessionState.LoggedIn => "logged_in",
+            SessionState.LoggedOut => "logged_out",
+            SessionState.Expired => "expired",
+            SessionState.LoggingIn => "logging_in",
+            _ => "logged_out"
+        };
+
+        public string nickname => _sessionManager.UserInfo?.Nickname ?? "";
+        public string avatarUrl => _sessionManager.UserInfo?.AvatarUrl ?? "";
+        public int vipType => _sessionManager.UserInfo?.VipType ?? 0;
+        public string statusMessage => _statusMessage;
+        public string qrCodeBase64 => _qrCodeBase64;
+
+        #endregion
+
+        #region Methods (called by JS UI buttons)
+
+        public void login()
+        {
+            _logger.LogInfo("[NeteaseAccountApi] Manual login triggered from UI");
+            _sessionManager.TriggerQRLogin();
+        }
+
+        public void logout()
+        {
+            _logger.LogInfo("[NeteaseAccountApi] Logout triggered from UI");
+            _sessionManager.Logout();
+            _statusMessage = "";
+            _qrCodeBase64 = "";
+        }
+
+        public async void refreshLogin()
+        {
+            _logger.LogInfo("[NeteaseAccountApi] Manual session refresh triggered");
+            var result = await _sessionManager.ValidateAndRefreshAsync();
+            _logger.LogDebug($"[NeteaseAccountApi] Session refresh result: {(result ? "success" : "failed")}");
+        }
+
+        #endregion
+    }
+}

--- a/ChillPatcher.Module.Netease/NeteaseBridge.cs
+++ b/ChillPatcher.Module.Netease/NeteaseBridge.cs
@@ -31,6 +31,9 @@ namespace ChillPatcher.Module.Netease
         private static extern int NeteaseRefreshLogin();
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int NeteaseLogout();
+
+        [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr NeteaseGetLikeSongs(int getAll);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
@@ -139,6 +142,9 @@ namespace ChillPatcher.Module.Netease
 
             [JsonProperty("avatarUrl")]
             public string AvatarUrl { get; set; }
+
+            [JsonProperty("vipType")]
+            public int VipType { get; set; }
         }
 
         /// <summary>
@@ -189,6 +195,19 @@ namespace ChillPatcher.Module.Netease
 
             [JsonProperty("type")]
             public string Type { get; set; } // mp3, flac, etc.
+
+            [JsonProperty("isTrial")]
+            public bool IsTrial { get; set; }
+        }
+
+        /// <summary>
+        /// RefreshLogin 结果
+        /// </summary>
+        public enum RefreshLoginResult
+        {
+            Success,
+            AuthFailed,
+            NetworkError
         }
 
         /// <summary>
@@ -439,22 +458,55 @@ namespace ChillPatcher.Module.Netease
         /// <summary>
         /// 刷新登录状态
         /// </summary>
-        public bool RefreshLogin()
+        public RefreshLoginResult RefreshLogin()
+        {
+            if (!_initialized) return RefreshLoginResult.NetworkError;
+
+            try
+            {
+                var result = NeteaseRefreshLogin();
+                switch (result)
+                {
+                    case 1:
+                        return RefreshLoginResult.Success;
+                    case -1:
+                        _logger.LogWarning($"[NeteaseBridge] RefreshLogin network error: {GetLastErrorMessage()}");
+                        return RefreshLoginResult.NetworkError;
+                    default:
+                        _logger.LogWarning($"[NeteaseBridge] RefreshLogin auth failed: {GetLastErrorMessage()}");
+                        return RefreshLoginResult.AuthFailed;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"[NeteaseBridge] RefreshLogin exception: {ex}");
+                return RefreshLoginResult.NetworkError;
+            }
+        }
+
+        /// <summary>
+        /// 登出
+        /// </summary>
+        public bool Logout()
         {
             if (!_initialized) return false;
 
             try
             {
-                var result = NeteaseRefreshLogin();
+                var result = NeteaseLogout();
                 if (result != 1)
                 {
-                    _logger.LogWarning($"[NeteaseBridge] RefreshLogin failed: {GetLastErrorMessage()}");
+                    _logger.LogWarning($"[NeteaseBridge] Logout failed: {GetLastErrorMessage()}");
+                }
+                else
+                {
+                    _logger.LogInfo("[NeteaseBridge] Logout completed");
                 }
                 return result == 1;
             }
             catch (Exception ex)
             {
-                _logger.LogError($"[NeteaseBridge] RefreshLogin exception: {ex}");
+                _logger.LogError($"[NeteaseBridge] Logout exception: {ex}");
                 return false;
             }
         }

--- a/ChillPatcher.Module.Netease/NeteaseModule.cs
+++ b/ChillPatcher.Module.Netease/NeteaseModule.cs
@@ -30,7 +30,9 @@ namespace ChillPatcher.Module.Netease
         private NeteaseFavoriteManager _favoriteManager;
         private NeteaseSongRegistry _songRegistry;
         private QRLoginManager _qrLoginManager;
-        
+        private NeteaseSessionManager _sessionManager;
+        private NeteaseAccountApi _accountApi;
+
         private List<MusicInfo> _musicList = new List<MusicInfo>();
         private List<MusicInfo> _fmMusicList = new List<MusicInfo>();
         private Dictionary<string, NeteaseBridge.SongInfo> _songInfoMap = new Dictionary<string, NeteaseBridge.SongInfo>();
@@ -119,7 +121,11 @@ namespace ChillPatcher.Module.Netease
                 _qrLoginManager.OnLoginSuccess += OnQRLoginSuccess;
                 _qrLoginManager.OnStatusChanged += OnQRLoginStatusChanged;
                 _qrLoginManager.OnQRCodeUpdated += OnQRCodeUpdated;
-                
+
+                // 初始化会话管理器（未登录状态，绑定 QR 登录）
+                _sessionManager = new NeteaseSessionManager(_bridge, context.Logger);
+                _sessionManager.SetQRLoginManager(_qrLoginManager);
+
                 // 注册收藏专辑（包含登录歌曲）
                 RegisterLoginSongAlbum();
                 
@@ -129,12 +135,21 @@ namespace ChillPatcher.Module.Netease
                 // 监听播放事件：切换到其他歌曲时取消 QR 等待
                 _playStartedSubscription = _context.EventBus.Subscribe<PlayStartedEvent>(OnPlayStartedBeforeLogin);
 
+                // 注册账户 API（未登录模式也需要，供 UI 触发登录）
+                _accountApi = new NeteaseAccountApi(_sessionManager, context.Logger);
+                _accountApi.SetQRLoginManager(_qrLoginManager);
+                RegisterAccountApi();
+
                 _isReady = true;
                 OnReadyStateChanged?.Invoke(_isReady);
-                
+
                 context.Logger.LogInfo($"[{DisplayName}] ✅ 初始化完成（未登录模式）");
                 return;
             }
+
+            // 初始化会话管理器（已登录状态，验证会话并获取 VIP 信息）
+            _sessionManager = new NeteaseSessionManager(_bridge, context.Logger);
+            await _sessionManager.ValidateAndRefreshAsync();
 
             // 获取用户信息
             var userInfo = _bridge.GetUserInfo();
@@ -179,8 +194,10 @@ namespace ChillPatcher.Module.Netease
             // 订阅收藏变化事件
             SubscribeToFavoriteEvents();
 
-            // 注册歌词 API
+            // 注册歌词 API 和账户 API
             RegisterLyricApi();
+            _accountApi = new NeteaseAccountApi(_sessionManager, context.Logger);
+            RegisterAccountApi();
 
             _isReady = true;
             OnReadyStateChanged?.Invoke(_isReady);
@@ -210,6 +227,8 @@ namespace ChillPatcher.Module.Netease
             _qrLoginManager?.CancelLogin();
             _playStartedSubscription?.Dispose();
             _playStartedSubscription = null;
+            _sessionManager = null;
+            _accountApi = null;
             _musicList.Clear();
             _fmMusicList.Clear();
             _songInfoMap.Clear();
@@ -301,6 +320,26 @@ namespace ChillPatcher.Module.Netease
                         continue;
                     }
                     return null;
+                }
+
+                // 试听检测：IsTrial 由 bridge 层标记，触发会话恢复流程
+                if (songUrl.IsTrial && _sessionManager != null)
+                {
+                    _context.Logger.LogWarning($"[{DisplayName}] Trial song detected: {songInfo.Name}, attempting recovery...");
+                    var recoveryResult = await _sessionManager.HandleTrialAsync(songInfo.Id, bridgeQuality, cancellationToken);
+                    switch (recoveryResult)
+                    {
+                        case TrialRecoveryResult.Recovered:
+                            songUrl = _sessionManager.RecoveredSongUrl;
+                            _context.Logger.LogInfo($"[{DisplayName}] Recovery succeeded for: {songInfo.Name}");
+                            break;
+                        case TrialRecoveryResult.VipRestricted:
+                            _context.Logger.LogWarning($"[{DisplayName}] Song requires VIP: {songInfo.Name}, skipping");
+                            return null;
+                        case TrialRecoveryResult.NetworkError:
+                            _context.Logger.LogWarning($"[{DisplayName}] Network error during recovery for: {songInfo.Name}, skipping");
+                            return null;
+                    }
                 }
 
                 // 确定格式
@@ -685,6 +724,9 @@ namespace ChillPatcher.Module.Netease
             _context.Logger.LogInfo($"[{DisplayName}] 二维码登录成功！");
             _isLoggedIn = true;
 
+            // 通知会话管理器登录成功
+            _sessionManager?.NotifyLoginSuccess();
+
             // 停止登录前的播放监听
             _playStartedSubscription?.Dispose();
             _playStartedSubscription = null;
@@ -732,8 +774,9 @@ namespace ChillPatcher.Module.Netease
             // 订阅收藏变化事件
             SubscribeToFavoriteEvents();
 
-            // 注册歌词 API
+            // 注册歌词 API 和账户 API
             RegisterLyricApi();
+            RegisterAccountApi();
 
             // 统计自定义歌单歌曲数
             var customSongCount = _customPlaylistMusicLists.Values.Sum(list => list.Count);
@@ -790,6 +833,12 @@ namespace ChillPatcher.Module.Netease
             EnsureLyricApiRegistrationLoop();
         }
 
+        private void RegisterAccountApi()
+        {
+            // 账户 API 注册已集成到同一个循环中，确保循环正在运行
+            EnsureLyricApiRegistrationLoop();
+        }
+
         private void EnsureLyricApiRegistrationLoop()
         {
             if (_lyricApiRegistrationTask != null && !_lyricApiRegistrationTask.IsCompleted) return;
@@ -840,18 +889,32 @@ namespace ChillPatcher.Module.Netease
                         withJsApi++;
 
                         var getMethod = jsApi.GetType().GetMethod("GetCustomApi");
-                        var existing = getMethod?.Invoke(jsApi, new object[] { "lyric_netease" });
-                        if (existing != null) continue;
-
-                        var lyricApi = new NeteaseLyricApi(_bridge, _songInfoMap, _context.Logger);
                         var registerMethod = jsApi.GetType().GetMethod("RegisterCustomApi");
-                        registerMethod?.Invoke(jsApi, new object[] { "lyric_netease", lyricApi });
-                        newlyRegistered++;
+
+                        // 注册歌词 API
+                        var existingLyric = getMethod?.Invoke(jsApi, new object[] { "lyric_netease" });
+                        if (existingLyric == null)
+                        {
+                            var lyricApi = new NeteaseLyricApi(_bridge, _songInfoMap, _context.Logger);
+                            registerMethod?.Invoke(jsApi, new object[] { "lyric_netease", lyricApi });
+                            newlyRegistered++;
+                        }
+
+                        // 注册账户 API
+                        if (_accountApi != null)
+                        {
+                            var existingAccount = getMethod?.Invoke(jsApi, new object[] { "netease_account" });
+                            if (existingAccount == null)
+                            {
+                                registerMethod?.Invoke(jsApi, new object[] { "netease_account", _accountApi });
+                                newlyRegistered++;
+                            }
+                        }
                     }
 
                     if (newlyRegistered > 0)
                     {
-                        _context.Logger.LogInfo($"[{DisplayName}] Lyric API (netease) registered on {withJsApi} ready instance(s), newly attached to {newlyRegistered} instance(s)");
+                        _context.Logger.LogInfo($"[{DisplayName}] Custom APIs registered on {withJsApi} ready instance(s), newly attached {newlyRegistered} registration(s)");
                     }
                 }
                 catch (OperationCanceledException)
@@ -860,7 +923,7 @@ namespace ChillPatcher.Module.Netease
                 }
                 catch (Exception ex)
                 {
-                    _context.Logger.LogError($"[{DisplayName}] Lyric API (netease) registration loop failed: {ex.Message}");
+                    _context.Logger.LogError($"[{DisplayName}] Custom API registration loop failed: {ex.Message}");
                 }
 
                 await Task.Delay(1000, cancellationToken);

--- a/ChillPatcher.Module.Netease/NeteaseSessionManager.cs
+++ b/ChillPatcher.Module.Netease/NeteaseSessionManager.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BepInEx.Logging;
+
+namespace ChillPatcher.Module.Netease
+{
+    public enum SessionState
+    {
+        LoggedOut,
+        LoggedIn,
+        Expired,
+        LoggingIn
+    }
+
+    public enum TrialRecoveryResult
+    {
+        Recovered,
+        VipRestricted,
+        NetworkError
+    }
+
+    /// <summary>
+    /// 网易云登录会话管理器。
+    /// 负责：验证会话 → 静默刷新 → 试听恢复 → QR 重登录 的完整生命周期。
+    /// </summary>
+    public class NeteaseSessionManager
+    {
+        private readonly ManualLogSource _logger;
+        private readonly NeteaseBridge _bridge;
+        private QRLoginManager _qrLoginManager;
+
+        private TaskCompletionSource<bool> _loginTcs;
+
+        public SessionState State { get; private set; } = SessionState.LoggedOut;
+        public NeteaseBridge.UserInfo UserInfo { get; private set; }
+
+        /// <summary>
+        /// 试听恢复后拿到的完整 URL，供调用方直接使用。
+        /// </summary>
+        public NeteaseBridge.SongUrl RecoveredSongUrl { get; private set; }
+
+        public event Action<SessionState> OnStateChanged;
+
+        public NeteaseSessionManager(NeteaseBridge bridge, ManualLogSource logger)
+        {
+            _bridge = bridge;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// 设置 QRLoginManager（构造时可能尚未就绪）。
+        /// </summary>
+        public void SetQRLoginManager(QRLoginManager qrLoginManager)
+        {
+            _qrLoginManager = qrLoginManager;
+            _qrLoginManager.OnLoginSuccess += OnQRLoginSuccess;
+        }
+
+        #region Public API
+
+        /// <summary>
+        /// 启动时校验会话并刷新用户信息。
+        /// </summary>
+        public async Task<bool> ValidateAndRefreshAsync()
+        {
+            _logger.LogInfo("[NeteaseSession] Validating session...");
+
+            var result = await Task.Run(() => CallRefreshLogin());
+
+            switch (result)
+            {
+                case NeteaseBridge.RefreshLoginResult.Success:
+                    UpdateUserInfo();
+                    SetState(SessionState.LoggedIn);
+                    _logger.LogInfo($"[NeteaseSession] Session valid. User: {UserInfo?.Nickname}, VipType: {UserInfo?.VipType}");
+                    return true;
+
+                case NeteaseBridge.RefreshLoginResult.AuthFailed:
+                    SetState(SessionState.Expired);
+                    _logger.LogWarning("[NeteaseSession] Session expired (auth failed)");
+                    return false;
+
+                case NeteaseBridge.RefreshLoginResult.NetworkError:
+                    _logger.LogWarning("[NeteaseSession] Network error during validation, keeping current state");
+                    return false;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// 检测到试听后触发恢复流程：静默刷新 → QR 重登录。
+        /// </summary>
+        public async Task<TrialRecoveryResult> HandleTrialAsync(
+            long songId,
+            NeteaseBridge.Quality quality,
+            CancellationToken cancellationToken = default)
+        {
+            _logger.LogInfo($"[NeteaseSession] Trial detected for song {songId}, attempting recovery...");
+
+            var previousState = State;
+
+            // Step 1: 静默刷新
+            var refreshResult = await Task.Run(() => CallRefreshLogin(), cancellationToken);
+
+            switch (refreshResult)
+            {
+                case NeteaseBridge.RefreshLoginResult.NetworkError:
+                    SetState(previousState);
+                    _logger.LogWarning("[NeteaseSession] Network error during trial recovery, skipping");
+                    return TrialRecoveryResult.NetworkError;
+
+                case NeteaseBridge.RefreshLoginResult.Success:
+                    UpdateUserInfo();
+                    SetState(SessionState.LoggedIn);
+                    _logger.LogInfo("[NeteaseSession] Silent refresh succeeded, retrying song URL...");
+                    return await RetryGetSongUrl(songId, quality, cancellationToken);
+
+                case NeteaseBridge.RefreshLoginResult.AuthFailed:
+                    SetState(SessionState.Expired);
+                    _logger.LogWarning("[NeteaseSession] Auth failed, triggering QR login...");
+
+                    // Step 2: QR 重登录
+                    if (_qrLoginManager == null)
+                    {
+                        _logger.LogError("[NeteaseSession] QRLoginManager not available, cannot recover");
+                        return TrialRecoveryResult.NetworkError;
+                    }
+
+                    TriggerQRLogin();
+
+                    try
+                    {
+                        var loginSuccess = await WaitWithCancellationAsync(_loginTcs.Task, cancellationToken);
+                        if (!loginSuccess)
+                        {
+                            _logger.LogWarning("[NeteaseSession] QR login was not successful");
+                            return TrialRecoveryResult.NetworkError;
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        _logger.LogInfo("[NeteaseSession] Trial recovery cancelled (song changed?)");
+                        return TrialRecoveryResult.NetworkError;
+                    }
+
+                    _logger.LogInfo("[NeteaseSession] QR login succeeded, retrying song URL...");
+                    return await RetryGetSongUrl(songId, quality, cancellationToken);
+
+                default:
+                    return TrialRecoveryResult.NetworkError;
+            }
+        }
+
+        /// <summary>
+        /// 主动触发 QR 登录（UI 按钮等场景调用）。
+        /// </summary>
+        public void TriggerQRLogin()
+        {
+            _loginTcs = new TaskCompletionSource<bool>();
+            SetState(SessionState.LoggingIn);
+            _qrLoginManager?.StartLoginAsync();
+            _logger.LogInfo("[NeteaseSession] QR login triggered");
+        }
+
+        /// <summary>
+        /// 登出。
+        /// </summary>
+        public void Logout()
+        {
+            _logger.LogInfo("[NeteaseSession] Logging out...");
+            var result = _bridge.Logout();
+            UserInfo = null;
+            RecoveredSongUrl = null;
+            SetState(SessionState.Expired);
+            _logger.LogInfo($"[NeteaseSession] Logout completed: {(result ? "success" : "failed")}");
+        }
+
+        /// <summary>
+        /// 外部通知：QR 登录成功（从 NeteaseModule 现有回调调用）。
+        /// </summary>
+        public void NotifyLoginSuccess()
+        {
+            UpdateUserInfo();
+            SetState(SessionState.LoggedIn);
+            _loginTcs?.TrySetResult(true);
+            _logger.LogInfo($"[NeteaseSession] Login success notified. User: {UserInfo?.Nickname}");
+        }
+
+        /// <summary>
+        /// 外部通知：QR 登录失败。
+        /// </summary>
+        public void NotifyLoginFailed(string reason)
+        {
+            _loginTcs?.TrySetResult(false);
+            _logger.LogWarning($"[NeteaseSession] Login failed: {reason}");
+        }
+
+        #endregion
+
+        #region Private
+
+        private void OnQRLoginSuccess()
+        {
+            NotifyLoginSuccess();
+        }
+
+        private async Task<TrialRecoveryResult> RetryGetSongUrl(
+            long songId,
+            NeteaseBridge.Quality quality,
+            CancellationToken cancellationToken)
+        {
+            var songUrl = await Task.Run(() => _bridge.GetSongUrl(songId, quality), cancellationToken);
+
+            if (songUrl == null)
+            {
+                _logger.LogWarning($"[NeteaseSession] Retry GetSongUrl returned null for song {songId}");
+                return TrialRecoveryResult.NetworkError;
+            }
+
+            if (songUrl.IsTrial)
+            {
+                _logger.LogWarning($"[NeteaseSession] Song {songId} still trial after recovery — VIP restricted");
+                return TrialRecoveryResult.VipRestricted;
+            }
+
+            RecoveredSongUrl = songUrl;
+            _logger.LogInfo($"[NeteaseSession] Song {songId} recovered successfully");
+            return TrialRecoveryResult.Recovered;
+        }
+
+        /// <summary>
+        /// 调用 bridge 的 RefreshLogin()，直接返回枚举结果。
+        /// </summary>
+        private NeteaseBridge.RefreshLoginResult CallRefreshLogin()
+        {
+            return _bridge.RefreshLogin();
+        }
+
+        private void UpdateUserInfo()
+        {
+            try
+            {
+                UserInfo = _bridge.GetUserInfo();
+                _logger.LogDebug($"[NeteaseSession] UserInfo updated: {UserInfo?.Nickname}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"[NeteaseSession] Failed to update UserInfo: {ex.Message}");
+            }
+        }
+
+        private void SetState(SessionState newState)
+        {
+            if (State == newState) return;
+            var oldState = State;
+            State = newState;
+            _logger.LogInfo($"[NeteaseSession] State: {oldState} -> {newState}");
+            OnStateChanged?.Invoke(newState);
+        }
+
+        /// <summary>
+        /// net472 没有 Task.WaitAsync(CancellationToken)，用 CancellationToken.Register 模拟。
+        /// </summary>
+        private static async Task<T> WaitWithCancellationAsync<T>(Task<T> task, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            using (cancellationToken.Register(() => tcs.TrySetResult(true)))
+            {
+                var completed = await Task.WhenAny(task, tcs.Task);
+                if (completed == tcs.Task)
+                {
+                    throw new OperationCanceledException(cancellationToken);
+                }
+                return await task;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/docs/superpowers/specs/2026-04-01-netease-auth-trial-detection-design.md
+++ b/docs/superpowers/specs/2026-04-01-netease-auth-trial-detection-design.md
@@ -1,0 +1,309 @@
+# 网易云音乐认证恢复与试听检测
+
+> 解决 [#58](https://github.com/BeyondtheApex/ChillPatcher/issues/58)：网易云播放时歌曲无法完播，cookie 过期后静默降级为试听片段。
+
+## 问题根因
+
+1. **Fallback API 不检测试听**：`NeteaseGetSongURL` 的 v1 API 正确检测了 `FreeTrialInfo`，但 fallback API（`SongUrlService`）的响应结构体缺少该字段，盲目接受试听 URL
+2. **无 cookie 过期感知**：运行时从不验证 cookie 有效性，过期后所有歌曲静默降级为 ~30s 试听
+3. **无恢复机制**：播放器收到 EOF 后直接跳到下一首，无法区分"歌曲播完"和"试听结束"
+4. **无账号管理 UI**：没有登录状态显示、登出、重新登录入口
+
+## 设计方案
+
+采用分层架构（方案 B），新增 `NeteaseSessionManager` 管理认证生命周期，不改动现有 `QRLoginManager`。
+
+### 恢复策略
+
+静默 `RefreshLogin` 优先，失败则自动弹 QR 登录。当前歌曲暂停等待恢复，恢复后重新 resolve。
+
+## 1. Go Bridge 层改动
+
+### 1.1 SongURL — 试听标记
+
+`SongURL` struct 新增 `IsTrial bool` 字段：
+
+```go
+type SongURL struct {
+    ID      int64  `json:"id"`
+    URL     string `json:"url"`
+    Size    int64  `json:"size"`
+    Type    string `json:"type"`
+    IsTrial bool   `json:"isTrial"`
+}
+```
+
+`NeteaseGetSongURL` 改动：
+
+- Fallback API 响应结构体加上 `FreeTrialInfo interface{}` 字段
+- 两个 API 都检测到试听时，仍返回试听 URL（C# 层决定是否使用），但设置 `IsTrial: true`
+- 返回试听 URL 而非 null 的原因：C# 层可以选择先播着等重新登录
+
+兼容性：JSON 新增字段是纯加法，旧版 C# 没有此属性会自动忽略，默认 `false`。
+
+### 1.2 UserInfo — VIP 状态
+
+`UserInfo` struct 新增 `VipType int` 字段：
+
+```go
+type UserInfo struct {
+    UserID    int64  `json:"userId"`
+    Nickname  string `json:"nickname"`
+    AvatarURL string `json:"avatarUrl"`
+    VipType   int    `json:"vipType"`
+}
+```
+
+- `NeteaseRefreshLogin` 从 `AccountInfo()` 的 raw JSON 额外提取 `profile.vipType`
+- `NeteaseGetUserInfo` 返回时包含 `vipType`
+
+兼容性：老用户升级后首次启动 `vipType=0`（显示为"免费用户"），一次 `RefreshLogin` 后更新为真实值。
+
+### 1.3 NeteaseLogout — 新增函数
+
+```go
+//export NeteaseLogout
+func NeteaseLogout() C.int
+```
+
+执行：
+1. 清除内存中 `currentUser`
+2. 删除 cookie 文件（`{dataDir}/cookie`）
+3. 用空 jar 替换全局 cookie jar
+4. 清除本地 DB 中的用户信息
+
+### 1.4 错误码区分
+
+`NeteaseRefreshLogin` 需要区分网络错误和认证错误：
+
+| 返回值 | 含义 |
+|--------|------|
+| 1 | 成功 |
+| 0 | 认证失败（cookie 无效） |
+| -1 | 网络错误（超时/DNS/连接失败） |
+
+判断依据：HTTP 请求层错误 → 网络错误；HTTP 200 但账号信息获取失败 → 认证失败。
+
+## 2. C# Bridge 层改动
+
+### NeteaseBridge.cs
+
+- `SongUrl` model 加 `bool IsTrial` 属性（`[JsonProperty("isTrial")]`）
+- `UserInfo` 加 `int VipType` 属性（`[JsonProperty("vipType")]`）
+- 新增 `Logout()` P/Invoke 包装
+- `RefreshLogin()` 返回值映射为枚举：`Success` / `AuthFailed` / `NetworkError`
+
+## 3. NeteaseSessionManager（新文件）
+
+### 职责
+
+认证生命周期的单一入口。NeteaseModule 只通过它处理认证相关的一切。
+
+### 类结构
+
+```csharp
+public class NeteaseSessionManager
+{
+    // 状态
+    public SessionState State { get; }       // LoggedIn / Expired / LoggingIn / LoggedOut
+    public UserInfo UserInfo { get; }        // 昵称/头像/VipType
+    public event Action<SessionState> OnStateChanged;
+
+    // 核心方法
+    public async Task<bool> ValidateAndRefreshAsync()
+    public void TriggerQRLogin()
+    public void Logout()
+
+    // 试听恢复，Recovered 时 RecoveredSongUrl 包含新的完整 URL
+    public async Task<TrialRecoveryResult> HandleTrialAsync(long songId, string quality)
+    public SongUrl RecoveredSongUrl { get; }  // HandleTrialAsync 恢复成功后的新 URL
+}
+
+public enum SessionState { LoggedOut, LoggedIn, Expired, LoggingIn }
+public enum TrialRecoveryResult { Recovered, VipRestricted, NetworkError }
+```
+
+### 与现有组件的关系
+
+```
+NeteaseModule
+  ├─ NeteaseSessionManager (new)
+  │    ├─ calls NeteaseBridge (RefreshLogin, IsLoggedIn, GetUserInfo, Logout)
+  │    ├─ calls QRLoginManager (StartLogin, CancelLogin) ← 不改 QRLoginManager
+  │    └─ exposes ICustomJSApi → UI 面板
+  └─ ResolveAsync()
+       └─ 检测 isTrial → sessionManager.HandleTrialAsync()
+```
+
+### HandleTrialAsync 流程
+
+```
+HandleTrialAsync(songId, quality):
+  1. previousState = State
+  2. RefreshLogin()
+     → 网络错误 → State = previousState（回滚），return NetworkError
+     → 认证失败 → State = Expired
+       3. TriggerQRLogin()
+       4. State = LoggingIn
+       5. await QR 登录成功回调
+       6. 重新 GetSongUrl(songId, quality)
+         → 非 trial → return Recovered
+         → 仍 trial → return VipRestricted
+     → 成功 → State = LoggedIn
+       → 重新 GetSongUrl(songId, quality)
+         → 非 trial → return Recovered
+         → 仍 trial → return VipRestricted
+```
+
+### NeteaseModule.ResolveAsync 改动
+
+```csharp
+var songUrl = await GetSongUrl(songId, quality);
+if (songUrl.IsTrial)
+{
+    var result = await _sessionManager.HandleTrialAsync(songId, quality);
+    switch (result)
+    {
+        case Recovered:
+            songUrl = _sessionManager.RecoveredSongUrl; // 直接使用恢复后的 URL
+            break;
+        case VipRestricted:
+            _logger.LogWarning($"Song {songId} requires VIP, skipping");
+            return null;
+        case NetworkError:
+            _logger.LogWarning($"Network unavailable, skipping song {songId}");
+            return null;
+    }
+}
+```
+
+### 初始化时机
+
+模块 `InitializeAsync` 中，`IsLoggedIn == true` 时主动调用 `ValidateAndRefreshAsync()`：
+- 刷新 VIP 状态（解决老用户升级后 vipType=0 的问题）
+- 提前发现 cookie 过期
+
+## 4. NeteaseAccountApi（新文件）
+
+注册为 `chill.custom.get("netease_account")`。
+
+### 属性（UI 轮询读取）
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `sessionState` | string | `"logged_in"` / `"logged_out"` / `"expired"` / `"logging_in"` |
+| `nickname` | string | 昵称，未登录时 `""` |
+| `avatarUrl` | string | 头像 URL |
+| `vipType` | int | 0=免费, 11=黑胶VIP 等 |
+| `statusMessage` | string | QR 扫码状态提示文案 |
+| `qrCodeBase64` | string | QR 图片 base64 PNG，空串表示无 QR |
+
+### 操作（UI 按钮调用）
+
+| 方法 | 说明 |
+|------|------|
+| `triggerLogin()` | 手动触发 QR 登录 |
+| `logout()` | 登出 |
+| `refreshSession()` | 手动刷新登录态 |
+
+### 数据流
+
+```
+NeteaseSessionManager
+  ├─ State/UserInfo 变化 → 更新 NeteaseAccountApi 属性
+  └─ QRLoginManager.OnStatusChanged → 更新 statusMessage/qrCodeBase64
+
+UI (500ms poll)
+  ├─ 读属性 → 渲染
+  └─ 按钮点击 → 调操作方法
+```
+
+## 5. UI 面板
+
+### 文件位置
+
+`ui/window-manager/plugins/netease/index.tsx`
+
+### 界面结构
+
+```
+┌─────────────────────────────┐
+│  网易云音乐                   │
+├─────────────────────────────┤
+│  [头像]  昵称                 │
+│          黑胶VIP / 免费用户    │
+│          ● 已登录              │
+├─────────────────────────────┤
+│  [刷新登录态]  [登出]          │
+├─────────────────────────────┤
+│  (QR 登录区域 - 仅未登录/     │
+│   过期时显示)                  │
+│                               │
+│  [QR Code Image]              │
+│  请使用网易云 APP 扫码         │
+└─────────────────────────────┘
+```
+
+### 状态 → UI 映射
+
+| sessionState | 显示 |
+|---|---|
+| `logged_in` | 头像 + 昵称 + VIP 状态 + 绿色"已登录"，按钮：刷新 / 登出 |
+| `logged_out` | 灰色"未登录"，自动展开 QR 区域，按钮：登录 |
+| `expired` | 橙色"登录已过期"，自动展开 QR 区域，按钮：重新登录 / 登出 |
+| `logging_in` | "扫码中..." + statusMessage + QR 图片，按钮禁用 |
+
+### VIP 状态显示
+
+| vipType | 显示 | 颜色 |
+|---|---|---|
+| 0 | 免费用户 | textMuted |
+| 11 | 黑胶VIP | `#e7515a`（网易红） |
+| 其他非 0 | VIP | accent |
+
+### 样式
+
+沿用 `theme.ts` 配色，与 Spotify 面板风格一致。
+
+## 6. 边界条件
+
+| 场景 | 处理 |
+|---|---|
+| RefreshLogin 网络超时 | 返回 NetworkError，State 保持 LoggedIn，不触发 QR |
+| 用户断网 | 同上，不登出不弹 QR，等网络恢复后下一首重试 |
+| QR 登录中用户切歌 | HandleTrialAsync 的 context 被 cancel，新歌正常走 ResolveAsync |
+| 连续多首 trial | 第一首触发恢复流程，后续歌曲检查 `State == LoggingIn` 时等待（不重复触发 QR） |
+| 登出后正在播放的歌 | 不中断当前播放（已下载的流不受影响） |
+| QR 超时无人扫码 | 复用 QRLoginManager 现有逻辑：90s 后自动刷新 QR |
+| 启动时 cookie 已过期 | InitializeAsync 调 ValidateAndRefreshAsync → 失败 → State=Expired，UI 显示过期 |
+| VipType=0 但歌曲非 trial | 正常播放，VIP 仅供显示 |
+| 老用户升级 cookie 有效 | vipType=0 显示"免费用户"，一次 RefreshLogin 后更新真实值 |
+| Go bridge 新版 + C# 旧版 | 旧版忽略 isTrial/vipType 新字段，行为等同旧版 |
+
+## 7. 文件改动清单
+
+| 层 | 文件 | 改动类型 |
+|---|---|---|
+| Go bridge | `netease_bridge/main.go` | 修改 |
+| C# bridge | `ChillPatcher.Module.Netease/NeteaseBridge.cs` | 修改 |
+| C# module | `ChillPatcher.Module.Netease/NeteaseModule.cs` | 修改 |
+| C# 新文件 | `ChillPatcher.Module.Netease/NeteaseSessionManager.cs` | 新增 |
+| C# 新文件 | `ChillPatcher.Module.Netease/NeteaseAccountApi.cs` | 新增 |
+| UI 新文件 | `ui/window-manager/plugins/netease/index.tsx` | 新增 |
+
+### 不改动的文件
+
+| 文件 | 原因 |
+|---|---|
+| `QRLoginManager.cs` | 保持不变，被 SessionManager 调用 |
+| `pcm_cache.go` / `pcm_stream.go` | 缓存/流无需改动 |
+| `PluginConfig.cs` | 不新增配置项 |
+| `SettingsPanel.tsx` / `ModulesPanel.tsx` | 不改现有面板 |
+
+## 8. 日志规范
+
+所有关键路径都有日志，统一 `[NeteaseSession]` 前缀，便于 grep 排查：
+
+- **Info**：状态变迁（LoggedIn→Expired→LoggingIn→LoggedIn）、登录/登出操作、试听检测触发、HandleTrialAsync 结果
+- **Debug**：RefreshLogin 结果详情、GetSongUrl 的 isTrial 值、QR 状态轮询、VipType 解析、AccountApi 属性更新
+- **Warning**：RefreshLogin 失败原因（网络/认证）、连续 trial 检测、VipRestricted 跳过

--- a/netease_bridge/main.go
+++ b/netease_bridge/main.go
@@ -27,11 +27,12 @@ import (
 )
 
 var (
-	initialized  bool
-	initMutex    sync.Mutex
-	currentUser  *structs.User
-	lastError    string
-	dataDir      string
+	initialized    bool
+	initMutex      sync.Mutex
+	currentUser    *structs.User
+	lastError      string
+	dataDir        string
+	currentVipType int
 )
 
 // SongInfo 导出给 C# 的歌曲信息结构
@@ -47,17 +48,19 @@ type SongInfo struct {
 
 // UserInfo 用户信息
 type UserInfo struct {
-	UserID   int64  `json:"userId"`
-	Nickname string `json:"nickname"`
+	UserID    int64  `json:"userId"`
+	Nickname  string `json:"nickname"`
 	AvatarURL string `json:"avatarUrl"`
+	VipType   int    `json:"vipType"`
 }
 
 // SongURL 歌曲播放地址
 type SongURL struct {
-	ID   int64  `json:"id"`
-	URL  string `json:"url"`
-	Size int64  `json:"size"`
-	Type string `json:"type"` // mp3, flac, etc.
+	ID      int64  `json:"id"`
+	URL     string `json:"url"`
+	Size    int64  `json:"size"`
+	Type    string `json:"type"` // mp3, flac, etc.
+	IsTrial bool   `json:"isTrial"`
 }
 
 //export NeteaseInit
@@ -132,6 +135,7 @@ func NeteaseGetUserInfo() *C.char {
 		UserID:    currentUser.UserId,
 		Nickname:  currentUser.Nickname,
 		AvatarURL: currentUser.AvatarUrl,
+		VipType:   currentVipType,
 	}
 
 	jsonBytes, err := json.Marshal(info)
@@ -157,21 +161,39 @@ func NeteaseRefreshLogin() C.int {
 	// 获取账户信息
 	code, resp := (&service.UserAccountService{}).AccountInfo()
 	if code != 200 {
+		// 区分网络错误和认证错误
+		if resp == nil {
+			log.Printf("[NeteaseRefreshLogin] Network error: no response")
+			lastError = "Network error: no response from server"
+			return -1
+		}
+		log.Printf("[NeteaseRefreshLogin] Auth failed, code: %v", code)
 		lastError = "Failed to get account info, code: " + strconv.FormatFloat(code, 'f', 0, 64)
 		return 0
 	}
 
 	user, err := structs.NewUserFromJsonForLogin(resp)
 	if err != nil {
+		log.Printf("[NeteaseRefreshLogin] Failed to parse user info: %s", err.Error())
 		lastError = "Failed to parse user info: " + err.Error()
 		return 0
 	}
 	currentUser = &user
 
+	// 提取 VIP 类型
+	if vipType, err := jsonparser.GetInt(resp, "profile", "vipType"); err == nil {
+		currentVipType = int(vipType)
+		log.Printf("[NeteaseRefreshLogin] VipType: %d", currentVipType)
+	} else {
+		currentVipType = 0
+		log.Printf("[NeteaseRefreshLogin] Could not extract vipType: %s", err.Error())
+	}
+
 	// 保存用户信息
 	table := storage.NewTable()
 	_ = table.SetByKVModel(storage.User{}, user)
 
+	log.Printf("[NeteaseRefreshLogin] Success, user: %s (ID: %d, VIP: %d)", user.Nickname, user.UserId, currentVipType)
 	return 1
 }
 
@@ -258,6 +280,7 @@ func NeteaseGetSongURL(songId C.longlong, quality *C.char) *C.char {
 	}
 
 	needFallback := false
+	isTrial := false
 	var url string
 	var size int64
 	var musicType string
@@ -269,7 +292,12 @@ func NeteaseGetSongURL(songId C.longlong, quality *C.char) *C.char {
 				size = v1Response.Data[0].Size
 				musicType = v1Response.Data[0].Type
 				// 检查是否是试听歌曲（需要会员）
-				if url == "" || v1Response.Data[0].FreeTrialInfo != nil {
+				if v1Response.Data[0].FreeTrialInfo != nil {
+					isTrial = true
+					if url == "" {
+						needFallback = true
+					}
+				} else if url == "" {
 					needFallback = true
 				}
 			} else {
@@ -310,10 +338,11 @@ func NeteaseGetSongURL(songId C.longlong, quality *C.char) *C.char {
 
 		var fallbackResponse struct {
 			Data []struct {
-				ID   int64  `json:"id"`
-				URL  string `json:"url"`
-				Size int64  `json:"size"`
-				Type string `json:"type"`
+				ID            int64       `json:"id"`
+				URL           string      `json:"url"`
+				Size          int64       `json:"size"`
+				Type          string      `json:"type"`
+				FreeTrialInfo interface{} `json:"freeTrialInfo"`
 			} `json:"data"`
 		}
 
@@ -326,6 +355,9 @@ func NeteaseGetSongURL(songId C.longlong, quality *C.char) *C.char {
 			url = fallbackResponse.Data[0].URL
 			size = fallbackResponse.Data[0].Size
 			musicType = fallbackResponse.Data[0].Type
+			if fallbackResponse.Data[0].FreeTrialInfo != nil {
+				isTrial = true
+			}
 		}
 	}
 
@@ -339,11 +371,14 @@ func NeteaseGetSongURL(songId C.longlong, quality *C.char) *C.char {
 		musicType = "mp3"
 	}
 
+	log.Printf("[NeteaseGetSongURL] songId=%d, isTrial=%v, url=%s", int64(songId), isTrial, url[:min(50, len(url))])
+
 	result := SongURL{
-		ID:   int64(songId),
-		URL:  url,
-		Size: size,
-		Type: musicType,
+		ID:      int64(songId),
+		URL:     url,
+		Size:    size,
+		Type:    musicType,
+		IsTrial: isTrial,
 	}
 
 	jsonBytes, err := json.Marshal(result)
@@ -634,6 +669,39 @@ func fixStrategyCookies(jar http.CookieJar) {
 	jar.SetCookies(u, []*http.Cookie{
 		{Name: "NMTID", Value: realNMTID},
 	})
+}
+
+//export NeteaseLogout
+func NeteaseLogout() C.int {
+	if !initialized {
+		lastError = "Not initialized"
+		return 0
+	}
+
+	log.Printf("[NeteaseLogout] Logging out, clearing cookies and user data")
+
+	// 清除内存中的用户状态
+	currentUser = nil
+	currentVipType = 0
+
+	// 删除 cookie 文件
+	cookiePath := filepath.Join(dataDir, "cookie")
+	if err := os.Remove(cookiePath); err != nil {
+		log.Printf("[NeteaseLogout] Cookie file removal: %s", err.Error())
+	} else {
+		log.Printf("[NeteaseLogout] Cookie file removed: %s", cookiePath)
+	}
+
+	// 创建空的 cookie jar 替换当前的
+	emptyJar, _ := cookiejar.NewEntriesJar(nil)
+	util.SetGlobalCookieJar(emptyJar)
+
+	// 清除本地 DB 中的用户信息（用零值覆盖）
+	table := storage.NewTable()
+	_ = table.SetByKVModel(storage.User{}, structs.User{})
+	log.Printf("[NeteaseLogout] User data cleared from local DB")
+
+	return 1
 }
 
 func main() {

--- a/ui/window-manager/plugins/netease/index.tsx
+++ b/ui/window-manager/plugins/netease/index.tsx
@@ -1,0 +1,251 @@
+import { h } from "preact"
+import { useState, useEffect } from "preact/hooks"
+
+declare const chill: any
+declare const __registerPlugin: any
+
+// ---- Constants ----
+const NETEASE_RED = "#e7515a"
+const BG = "#0b1020"
+const CARD = "#111827"
+const TEXT = "#e5e7eb"
+const DIM = "#94a3b8"
+const BORDER = "rgba(255,255,255,0.08)"
+const SUCCESS = "#66BB6A"
+const WARNING = "#FFA726"
+const ACCENT = "#4FC3F7"
+
+// ---- Helper: get NetEase JSApi ----
+function getApi(): any {
+    return chill.custom?.get("netease_account") ?? null
+}
+
+// ---- VIP helpers ----
+function vipLabel(vipType: number): string {
+    return vipType > 0 ? "VIP" : "免费用户"
+}
+
+function vipColor(vipType: number): string {
+    return vipType > 0 ? NETEASE_RED : DIM
+}
+
+// ---- Session state helpers ----
+function statusDotColor(state: string): string {
+    switch (state) {
+        case "logged_in": return SUCCESS
+        case "expired": return WARNING
+        default: return DIM
+    }
+}
+
+function statusLabel(state: string): string {
+    switch (state) {
+        case "logged_in": return "已登录"
+        case "logged_out": return "未登录"
+        case "expired": return "登录已过期"
+        case "logging_in": return "扫码中..."
+        default: return "未知"
+    }
+}
+
+// ---- Sub-components ----
+
+const SectionTitle = ({ text }: { text: string }) => (
+    <div style={{
+        fontSize: 11, color: DIM, marginBottom: 6,
+        paddingLeft: 2, letterSpacing: 0.5,
+    }}>
+        {text.toUpperCase()}
+    </div>
+)
+
+const Separator = () => (
+    <div style={{ height: 1, backgroundColor: BORDER, marginTop: 10, marginBottom: 10 }} />
+)
+
+const ActionButton = ({ text, onClick, primary = false, disabled = false }: {
+    text: string; onClick: () => void; primary?: boolean; disabled?: boolean
+}) => (
+    <div
+        onClick={disabled ? undefined : onClick}
+        style={{
+            fontSize: 12,
+            color: disabled ? "rgba(255,255,255,0.3)" : (primary ? "#fff" : NETEASE_RED),
+            backgroundColor: disabled ? "rgba(255,255,255,0.04)" : (primary ? NETEASE_RED : "rgba(255,255,255,0.06)"),
+            paddingTop: 7, paddingBottom: 7,
+            paddingLeft: 16, paddingRight: 16,
+            borderRadius: 6, flexGrow: 1, marginLeft: 4, marginRight: 4,
+            unityTextAlign: "MiddleCenter",
+        }}
+    >
+        {text}
+    </div>
+)
+
+// ---- Account Info ----
+const AccountInfo = ({ state, nickname, avatar, vip }: {
+    state: string; nickname: string; avatar: string; vip: number
+}) => (
+    <div style={{
+        backgroundColor: CARD, borderRadius: 8, padding: 12, marginBottom: 10,
+        display: "Flex", flexDirection: "Column", alignItems: "Center",
+    }}>
+        {state === "logged_in" && avatar ? (
+            <img
+                src={avatar}
+                style={{
+                    width: 48, height: 48, borderRadius: 24,
+                    marginBottom: 8,
+                }}
+            />
+        ) : null}
+        <div style={{ fontSize: 13, color: TEXT, marginBottom: 2, unityTextAlign: "MiddleCenter" }}>
+            {state === "logged_in" ? (nickname || "网易云用户") : statusLabel(state)}
+        </div>
+        <div style={{
+            fontSize: 10,
+            color: state === "logged_in" ? vipColor(vip) : DIM,
+            unityTextAlign: "MiddleCenter",
+        }}>
+            {state === "logged_in" ? vipLabel(vip) : statusLabel(state)}
+        </div>
+    </div>
+)
+
+// ---- Login Guide Section ----
+const LoginGuide = ({ status, state }: {
+    status: string; state: string
+}) => (
+    <div style={{
+        display: "Flex", flexDirection: "Column", alignItems: "Center",
+        marginTop: 6, marginBottom: 6,
+    }}>
+        <div style={{
+            backgroundColor: CARD, borderRadius: 8,
+            padding: 16, marginBottom: 8,
+        }}>
+            <div style={{ fontSize: 12, color: TEXT, unityTextAlign: "MiddleCenter", marginBottom: 6 }}>
+                {state === "expired"
+                    ? "请重启游戏以重新登录"
+                    : status === "等待扫码"
+                    ? "请用网易云 APP 扫描封面区域的二维码"
+                    : "请在播放列表中点击「网易云扫码登录」"}
+            </div>
+            <div style={{ fontSize: 10, color: DIM, unityTextAlign: "MiddleCenter" }}>
+                {state === "expired"
+                    ? "重启后可在播放列表中扫码登录"
+                    : status === "等待扫码"
+                    ? "扫码后在手机上确认登录"
+                    : "二维码将显示在封面区域"}
+            </div>
+        </div>
+    </div>
+)
+
+// ---- Action Buttons ----
+const ActionButtons = ({ state }: { state: string }) => {
+    const api = getApi()
+    if (!api) return null
+
+    const isLoggingIn = state === "logging_in"
+
+    switch (state) {
+        case "logged_in":
+            return (
+                <div>
+                    <div style={{ display: "Flex", flexDirection: "Row", justifyContent: "SpaceBetween" }}>
+                        <ActionButton text="刷新登录态" onClick={() => api.refreshLogin()} />
+                        <ActionButton text="登出" onClick={() => api.logout()} />
+                    </div>
+                </div>
+            )
+        case "logged_out":
+        case "expired":
+        case "logging_in":
+            return null
+        default:
+            return null
+    }
+}
+
+// ---- Main Component ----
+const NeteaseMain = () => {
+    const [state, setState] = useState("logged_out")
+    const [nickname, setNickname] = useState("")
+    const [avatar, setAvatar] = useState("")
+    const [vip, setVip] = useState(0)
+    const [status, setStatus] = useState("")
+
+    // Poll API every 500ms
+    useEffect(() => {
+        const poll = () => {
+            const api = getApi()
+            if (!api) return
+            setState(api.sessionState || "logged_out")
+            setNickname(api.nickname || "")
+            setAvatar(api.avatarUrl || "")
+            setVip(api.vipType || 0)
+            setStatus(api.statusMessage || "")
+        }
+        const timer = setInterval(poll, 500)
+        poll()
+        return () => clearInterval(timer)
+    }, [])
+
+    const api = getApi()
+    const noApi = !api
+    const showLogin = state === "logged_out" || state === "expired" || state === "logging_in"
+
+    return (
+        <div style={{ flexGrow: 1, display: "Flex", flexDirection: "Column", backgroundColor: BG, padding: 16 }}>
+            {/* Header */}
+            <div style={{ display: "Flex", flexDirection: "Row", alignItems: "Center", marginBottom: 12 }}>
+                <div style={{ fontSize: 22, color: NETEASE_RED, marginRight: 8 }}>󰎆</div>
+                <div style={{ fontSize: 15, color: TEXT, unityFontStyleAndWeight: "Bold" }}>网易云音乐</div>
+            </div>
+
+            <Separator />
+
+            {noApi ? (
+                <div style={{ flexGrow: 1, display: "Flex", justifyContent: "Center", alignItems: "Center" }}>
+                    <div style={{ fontSize: 12, color: DIM }}>等待网易云模块加载...</div>
+                </div>
+            ) : (
+                <div style={{ flexGrow: 1 }}>
+                    <SectionTitle text="账号" />
+                    <AccountInfo state={state} nickname={nickname} avatar={avatar} vip={vip} />
+
+                    {showLogin && (
+                        <div>
+                            <SectionTitle text="登录" />
+                            <LoginGuide status={status} state={state} />
+                        </div>
+                    )}
+
+                    {state === "logged_in" && status ? (
+                        <div style={{ fontSize: 11, color: DIM, marginTop: 4 }}>{status}</div>
+                    ) : null}
+
+                    <div style={{ flexGrow: 1 }} />
+                    <Separator />
+                    <ActionButtons state={state} />
+                </div>
+            )}
+        </div>
+    )
+}
+
+// ---- Register ----
+__registerPlugin({
+    id: "netease",
+    title: "网易云音乐",
+    width: 280,
+    height: 360,
+    initialX: 260,
+    initialY: 140,
+    launcher: {
+        text: "󰎆",
+        background: "#e7515a",
+    },
+    component: NeteaseMain,
+})


### PR DESCRIPTION
## Summary

- **Go bridge**: `SongURL.isTrial` flag, `UserInfo.vipType`, `RefreshLogin` error codes (success/auth-failed/network-error), `NeteaseLogout`
- **C# bridge**: matching model extensions, `RefreshLoginResult` enum, `Logout()` P/Invoke
- **NeteaseSessionManager**: auth lifecycle management with silent refresh on trial detection
- **NeteaseAccountApi**: `ICustomJSApi` exposing session state, user info, and logout/refresh actions to the UI layer
- **NeteaseModule**: trial detection in `ResolveAsync`, startup session validation, AccountApi registration
- **UI panel**: account status display (nickname, VIP badge), login guide, logout with expired state flow

## Problem

When NetEase cookies expire, the API silently returns trial audio segments (~30s) instead of full tracks. Songs skip to the next after the trial ends with no user-visible indication of the auth failure (issue #58).

## Solution

Two-layer trial detection (Go marks `isTrial`, C# acts on it) with recovery attempt:

1. On trial detection → silent `RefreshLogin` attempt
2. If refresh succeeds → retry song URL, resume playback with full audio
3. If auth failed → set state to `Expired`, attempt QR login trigger (user needs to scan QR in playlist cover area)
4. If network error → preserve current state, log warning

Account UI panel provides:
- Session state visibility (logged in / expired / logging in)
- Manual refresh login button
- Logout button (sets `Expired` state, guides user to restart)

**Note**: QR code is displayed in the playlist cover area (game limitation — OneJS doesn't support data URI images), not in the account panel itself.

## Test plan

- [ ] Verify trial detection triggers silent refresh when cookies expire
- [ ] Verify successful refresh retries and plays full audio
- [ ] Verify expired state is shown when auth fails
- [ ] Verify account panel shows correct state (logged in / expired / logging in)
- [ ] Verify logout sets expired state and shows restart guide

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)