### PR TITLE
feat(smtc): 增强系统媒体控制 — 进度条同步、拖动定位、随机播放

### DIFF
--- a/Native/SmtcBridge.cs
+++ b/Native/SmtcBridge.cs
@@ -171,6 +171,22 @@ namespace ChillPatcher.Native
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern void SmtcSetPositionChangeRequestedCallback(PositionChangeRequestedCallbackDelegate callback);
 
+        // 随机播放
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int SmtcSetShuffleEnabled(int enabled);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int SmtcSetShuffleActive(int active);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int SmtcGetShuffleActive();
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void ShuffleChangeCallbackDelegate(int active);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        private static extern void SmtcSetShuffleChangeCallback(ShuffleChangeCallbackDelegate callback);
+
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr SmtcGetLastError();
 
@@ -184,6 +200,7 @@ namespace ChillPatcher.Native
         private static bool _dllLoaded = false;
         private static ButtonPressedCallbackDelegate _buttonCallbackDelegate;
         private static PositionChangeRequestedCallbackDelegate _positionCallbackDelegate;
+        private static ShuffleChangeCallbackDelegate _shuffleCallbackDelegate;
 
         /// <summary>
         /// 按钮按下事件
@@ -194,6 +211,11 @@ namespace ChillPatcher.Native
         /// 位置改变请求事件
         /// </summary>
         public static event Action<long> OnPositionChangeRequested;
+
+        /// <summary>
+        /// 随机播放状态改变请求事件（参数为新状态：true=开启）
+        /// </summary>
+        public static event Action<bool> OnShuffleChangeRequested;
 
         #endregion
 
@@ -224,11 +246,23 @@ namespace ChillPatcher.Native
                     return false;
                 }
 
-                // 设置回调
+                // 设置核心回调
                 _buttonCallbackDelegate = OnButtonPressedNative;
                 _positionCallbackDelegate = OnPositionChangeRequestedNative;
                 SmtcSetButtonPressedCallback(_buttonCallbackDelegate);
                 SmtcSetPositionChangeRequestedCallback(_positionCallbackDelegate);
+
+                // Shuffle 回调（需要新版 DLL，失败不影响核心功能）
+                try
+                {
+                    _shuffleCallbackDelegate = OnShuffleChangeNative;
+                    SmtcSetShuffleChangeCallback(_shuffleCallbackDelegate);
+                }
+                catch (Exception ex)
+                {
+                    _log.LogWarning($"Shuffle 回调注册失败（需要重新编译 ChillSmtcBridge.dll）: {ex.Message}");
+                    _shuffleCallbackDelegate = null;
+                }
 
                 _log.LogInfo("SMTC 初始化成功");
                 return true;
@@ -257,10 +291,12 @@ namespace ChillPatcher.Native
                 
                 SmtcSetButtonPressedCallback(null);
                 SmtcSetPositionChangeRequestedCallback(null);
+                try { SmtcSetShuffleChangeCallback(null); } catch { }
                 SmtcShutdown();
-                
+
                 _buttonCallbackDelegate = null;
                 _positionCallbackDelegate = null;
+                _shuffleCallbackDelegate = null;
                 
                 _log.LogInfo("SMTC 已关闭");
             }
@@ -385,6 +421,36 @@ namespace ChillPatcher.Native
         }
 
         /// <summary>
+        /// 启用/禁用随机播放按钮
+        /// </summary>
+        public static bool SetShuffleEnabled(bool enabled)
+        {
+            if (!IsInitialized()) return false;
+            try { return SmtcSetShuffleEnabled(enabled ? 1 : 0) == 0; }
+            catch { return false; }
+        }
+
+        /// <summary>
+        /// 设置随机播放状态
+        /// </summary>
+        public static bool SetShuffleActive(bool active)
+        {
+            if (!IsInitialized()) return false;
+            try { return SmtcSetShuffleActive(active ? 1 : 0) == 0; }
+            catch { return false; }
+        }
+
+        /// <summary>
+        /// 获取随机播放状态
+        /// </summary>
+        public static bool GetShuffleActive()
+        {
+            if (!IsInitialized()) return false;
+            try { return SmtcGetShuffleActive() != 0; }
+            catch { return false; }
+        }
+
+        /// <summary>
         /// 获取最后的错误消息
         /// </summary>
         public static string GetLastError()
@@ -439,6 +505,18 @@ namespace ChillPatcher.Native
             catch (Exception ex)
             {
                 _log.LogError($"位置回调异常: {ex.Message}");
+            }
+        }
+
+        private static void OnShuffleChangeNative(int active)
+        {
+            try
+            {
+                OnShuffleChangeRequested?.Invoke(active != 0);
+            }
+            catch (Exception ex)
+            {
+                _log.LogError($"随机播放回调异常: {ex.Message}");
             }
         }
 

--- a/NativePlugins/SmtcBridge/include/smtc_bridge.h
+++ b/NativePlugins/SmtcBridge/include/smtc_bridge.h
@@ -195,6 +195,40 @@ typedef void (*SmtcPositionChangeRequestedCallback)(long long positionMs);
  */
 SMTC_API void SmtcSetPositionChangeRequestedCallback(SmtcPositionChangeRequestedCallback callback);
 
+// ========== 随机播放控制 ==========
+
+/**
+ * 启用/禁用随机播放按钮
+ * @param enabled 1 启用, 0 禁用
+ * @return 0 成功
+ */
+SMTC_API int SmtcSetShuffleEnabled(int enabled);
+
+/**
+ * 设置随机播放状态
+ * @param active 1 开启, 0 关闭
+ * @return 0 成功
+ */
+SMTC_API int SmtcSetShuffleActive(int active);
+
+/**
+ * 获取随机播放状态
+ * @return 1 开启, 0 关闭
+ */
+SMTC_API int SmtcGetShuffleActive(void);
+
+/**
+ * 随机播放状态改变回调函数类型
+ * @param active 新的随机播放状态（1 开启, 0 关闭）
+ */
+typedef void (*SmtcShuffleChangeCallback)(int active);
+
+/**
+ * 设置随机播放状态改变回调
+ * @param callback 回调函数指针，NULL 取消回调
+ */
+SMTC_API void SmtcSetShuffleChangeCallback(SmtcShuffleChangeCallback callback);
+
 // ========== 错误处理 ==========
 
 /**

--- a/NativePlugins/SmtcBridge/src/smtc_bridge.cpp
+++ b/NativePlugins/SmtcBridge/src/smtc_bridge.cpp
@@ -39,9 +39,12 @@ static std::string g_lastError;
 // 回调函数指针
 static SmtcButtonPressedCallback g_buttonCallback = nullptr;
 static SmtcPositionChangeRequestedCallback g_positionCallback = nullptr;
+static SmtcShuffleChangeCallback g_shuffleCallback = nullptr;
 
 // 事件令牌
 static winrt::event_token g_buttonPressedToken;
+static winrt::event_token g_positionChangeToken;
+static winrt::event_token g_shuffleChangeToken;
 
 // ========== 辅助函数 ==========
 
@@ -138,9 +141,36 @@ SMTC_API int SmtcInitialize(void) {
             }
         });
         
+        // 注册进度拖动事件
+        g_positionChangeToken = g_smtc.PlaybackPositionChangeRequested([](
+            wm::SystemMediaTransportControls const& sender,
+            wm::PlaybackPositionChangeRequestedEventArgs const& args) {
+
+            if (g_positionCallback) {
+                auto position = args.RequestedPlaybackPosition();
+                long long positionMs = std::chrono::duration_cast<std::chrono::milliseconds>(position).count();
+                g_positionCallback(positionMs);
+            }
+        });
+
+        // 注册随机播放状态变更事件（ISystemMediaTransportControls2）
+        try {
+            auto smtc2 = g_smtc.as<wm::ISystemMediaTransportControls2>();
+            g_shuffleChangeToken = smtc2.ShuffleEnabledChangeRequested([](
+                wm::SystemMediaTransportControls const& sender,
+                wm::ShuffleEnabledChangeRequestedEventArgs const& args) {
+
+                if (g_shuffleCallback) {
+                    g_shuffleCallback(args.RequestedShuffleEnabled() ? 1 : 0);
+                }
+            });
+        } catch (...) {
+            // ISystemMediaTransportControls2 not available
+        }
+
         // 启用 SMTC
         g_smtc.IsEnabled(true);
-        
+
         g_initialized = true;
         g_lastError.clear();
         return 0;
@@ -169,6 +199,13 @@ SMTC_API void SmtcShutdown(void) {
                 g_smtc.ButtonPressed(g_buttonPressedToken);
             } catch (...) {}
             try {
+                g_smtc.PlaybackPositionChangeRequested(g_positionChangeToken);
+            } catch (...) {}
+            try {
+                auto smtc2 = g_smtc.as<wm::ISystemMediaTransportControls2>();
+                smtc2.ShuffleEnabledChangeRequested(g_shuffleChangeToken);
+            } catch (...) {}
+            try {
                 g_smtc.IsEnabled(false);
             } catch (...) {}
         }
@@ -192,6 +229,7 @@ SMTC_API void SmtcShutdown(void) {
         // 清理回调
         g_buttonCallback = nullptr;
         g_positionCallback = nullptr;
+        g_shuffleCallback = nullptr;
         
         g_initialized = false;
         
@@ -554,6 +592,53 @@ SMTC_API void SmtcSetButtonPressedCallback(SmtcButtonPressedCallback callback) {
 SMTC_API void SmtcSetPositionChangeRequestedCallback(SmtcPositionChangeRequestedCallback callback) {
     std::lock_guard<std::mutex> lock(g_mutex);
     g_positionCallback = callback;
+}
+
+// ========== 随机播放控制 ==========
+
+SMTC_API int SmtcSetShuffleEnabled(int enabled) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+
+    if (!g_initialized || !g_smtc) {
+        SetError("Not initialized");
+        return -1;
+    }
+
+    try {
+        auto smtc2 = g_smtc.as<wm::ISystemMediaTransportControls2>();
+        smtc2.ShuffleEnabled(enabled != 0);
+        return 0;
+    }
+    catch (const winrt::hresult_error& ex) {
+        SetError("WinRT error: " + winrt::to_string(ex.message()));
+        return -2;
+    }
+}
+
+SMTC_API int SmtcSetShuffleActive(int active) {
+    // ShuffleEnabled 即 ShuffleActive（WinRT API 只有一个属性）
+    return SmtcSetShuffleEnabled(active);
+}
+
+SMTC_API int SmtcGetShuffleActive(void) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+
+    if (!g_initialized || !g_smtc) {
+        return 0;
+    }
+
+    try {
+        auto smtc2 = g_smtc.as<wm::ISystemMediaTransportControls2>();
+        return smtc2.ShuffleEnabled() ? 1 : 0;
+    }
+    catch (...) {
+        return 0;
+    }
+}
+
+SMTC_API void SmtcSetShuffleChangeCallback(SmtcShuffleChangeCallback callback) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_shuffleCallback = callback;
 }
 
 // ========== 错误处理 ==========

--- a/Patches/SystemMediaTransport_Patches.cs
+++ b/Patches/SystemMediaTransport_Patches.cs
@@ -17,6 +17,7 @@ namespace ChillPatcher.Patches
     {
         private static IDisposable _playMusicSubscription;
         private static IDisposable _changeMusicSubscription;
+        private static IDisposable _progressEventSubscription;
 
         /// <summary>
         /// 在 FacilityMusic.Setup 之后初始化 SMTC 服务
@@ -42,10 +43,18 @@ namespace ChillPatcher.Patches
                 // 释放旧订阅，防止场景重载后泄漏
                 _playMusicSubscription?.Dispose();
                 _changeMusicSubscription?.Dispose();
+                _progressEventSubscription?.Dispose();
 
                 // 订阅播放事件
                 _playMusicSubscription = __instance.MusicService.onPlayMusic.Subscribe(OnPlayMusic);
                 _changeMusicSubscription = __instance.MusicService.onChangeMusic.Subscribe(OnChangeMusic);
+
+                // 订阅进度事件，持续更新 SMTC 时间线
+                var eventBus = EventBus.Instance;
+                if (eventBus != null)
+                {
+                    _progressEventSubscription = eventBus.Subscribe<PlayProgressEvent>(OnPlayProgress);
+                }
                 
                 Plugin.Log.LogInfo("[SMTC] 服务已初始化并绑定到游戏");
             }
@@ -67,8 +76,14 @@ namespace ChillPatcher.Patches
                 SystemMediaTransportService.Instance.UpdateMediaInfo(audioInfo);
                 SystemMediaTransportService.Instance.SetPlaybackStatus(true);
                 
-                // 更新时间线（如果有音频长度）
-                if (audioInfo.AudioClip != null)
+                // 更新时间线：优先使用 PCM reader 的真实时长
+                var reader = MusicService_SetProgress_Patch.ActivePcmReader;
+                if (reader != null && reader.Info.Duration > 0)
+                {
+                    long durationMs = (long)(reader.Info.Duration * 1000);
+                    SystemMediaTransportService.Instance.UpdateTimeline(durationMs, 0);
+                }
+                else if (audioInfo.AudioClip != null)
                 {
                     long durationMs = (long)(audioInfo.AudioClip.length * 1000);
                     SystemMediaTransportService.Instance.UpdateTimeline(durationMs, 0);
@@ -87,6 +102,25 @@ namespace ChillPatcher.Patches
         {
             // 切换时状态会短暂变为 Changing
             // 实际信息由 OnPlayMusic 更新
+        }
+
+        /// <summary>
+        /// 每秒更新 SMTC 时间线位置
+        /// </summary>
+        private static void OnPlayProgress(PlayProgressEvent e)
+        {
+            try
+            {
+                if (e.TotalTime <= 0) return;
+
+                long durationMs = (long)(e.TotalTime * 1000);
+                long positionMs = (long)(e.CurrentTime * 1000);
+                SystemMediaTransportService.Instance.UpdateTimeline(durationMs, positionMs);
+            }
+            catch (Exception ex)
+            {
+                Plugin.Log.LogError($"[SMTC] OnPlayProgress 异常: {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/Patches/UIFramework/FacilityMusic_UpdateFacility_Patch.cs
+++ b/Patches/UIFramework/FacilityMusic_UpdateFacility_Patch.cs
@@ -168,7 +168,13 @@ namespace ChillPatcher.Patches.UIFramework
                 if (!string.IsNullOrEmpty(playingMusic?.UUID))
                     musicInfo = MusicRegistry.Instance?.GetMusic(playingMusic.UUID);
 
-                float totalTime = playingMusic?.AudioClip != null ? playingMusic.AudioClip.length : 0f;
+                // 优先使用 PCM reader 的真实时长（AudioClip.length 包含 30 分钟余量）
+                float totalTime;
+                var reader = MusicService_SetProgress_Patch.ActivePcmReader;
+                if (reader != null && reader.Info.Duration > 0)
+                    totalTime = reader.Info.Duration;
+                else
+                    totalTime = playingMusic?.AudioClip != null ? playingMusic.AudioClip.length : 0f;
                 float currentTime = totalTime * progress;
 
                 eventBus.Publish(new PlayProgressEvent

--- a/UIFramework/Audio/SystemMediaTransportService.cs
+++ b/UIFramework/Audio/SystemMediaTransportService.cs
@@ -32,6 +32,8 @@ namespace ChillPatcher.UIFramework.Audio
         private string _currentAlbum;
         private string _currentMusicUuid; // 当前播放的歌曲 UUID
         private bool _isPlaying;
+        private long _currentDurationMs; // 当前歌曲时长（用于 seek 换算）
+        private bool _lastShuffleState; // 上次同步的随机播放状态
 
         // 游戏服务引用
         private MusicService _musicService;
@@ -64,9 +66,14 @@ namespace ChillPatcher.UIFramework.Audio
                     return;
                 }
 
-                // 注册按钮事件
+                // 注册按钮事件、进度拖动事件和随机播放事件
                 SmtcBridge.OnButtonPressed += OnButtonPressed;
-                
+                SmtcBridge.OnPositionChangeRequested += OnPositionChangeRequested;
+                SmtcBridge.OnShuffleChangeRequested += OnShuffleChangeRequested;
+
+                // 启用随机播放按钮
+                SmtcBridge.SetShuffleEnabled(true);
+
                 // 订阅封面加载完成事件（用于异步更新封面）
                 CoverService.Instance.OnMusicCoverLoaded += OnMusicCoverLoaded;
                 
@@ -117,6 +124,9 @@ namespace ChillPatcher.UIFramework.Audio
         {
             _musicService = musicService;
             _facilityMusic = facilityMusic;
+
+            // 同步游戏当前的随机播放状态到 SMTC
+            SyncShuffleState();
         }
 
         /// <summary>
@@ -325,7 +335,96 @@ namespace ChillPatcher.UIFramework.Audio
         public void UpdateTimeline(long durationMs, long positionMs)
         {
             if (!_initialized) return;
+            _currentDurationMs = durationMs;
             SmtcBridge.SetTimelineProperties(0, durationMs, positionMs);
+
+            // 顺便检查随机播放状态是否从游戏侧变更
+            if (_musicService != null)
+            {
+                bool currentShuffle = _musicService.IsShuffle;
+                if (currentShuffle != _lastShuffleState)
+                {
+                    _lastShuffleState = currentShuffle;
+                    SmtcBridge.SetShuffleActive(currentShuffle);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 处理 SMTC 进度拖动事件
+        /// </summary>
+        private void OnPositionChangeRequested(long positionMs)
+        {
+            _log.LogDebug($"SMTC 进度拖动: {positionMs}ms");
+            MainThreadDispatcher.Instance?.Enqueue(() => HandlePositionChange(positionMs));
+        }
+
+        private void HandlePositionChange(long positionMs)
+        {
+            try
+            {
+                if (_musicService == null || _currentDurationMs <= 0) return;
+
+                float progress = (float)positionMs / _currentDurationMs;
+                progress = UnityEngine.Mathf.Clamp01(progress);
+                _musicService.SetMusicProgress(progress);
+
+                // 立即更新 SMTC 时间线，让进度条跟上
+                SmtcBridge.SetTimelineProperties(0, _currentDurationMs, positionMs);
+            }
+            catch (Exception ex)
+            {
+                _log.LogError($"处理进度拖动失败: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 处理 SMTC 随机播放按钮切换
+        /// </summary>
+        private void OnShuffleChangeRequested(bool active)
+        {
+            _log.LogDebug($"SMTC 随机播放: {active}");
+            MainThreadDispatcher.Instance?.Enqueue(() => HandleShuffleChange(active));
+        }
+
+        private void HandleShuffleChange(bool active)
+        {
+            try
+            {
+                if (_facilityMusic == null || _musicService == null) return;
+
+                // 只在状态不一致时才 toggle（游戏的 OnClickButtonShuffleChange 是 toggle）
+                if (_musicService.IsShuffle != active)
+                {
+                    _facilityMusic.OnClickButtonShuffleChange();
+                }
+                SmtcBridge.SetShuffleActive(active);
+                _lastShuffleState = active;
+                _log.LogInfo($"随机播放已{(active ? "开启" : "关闭")}");
+            }
+            catch (Exception ex)
+            {
+                _log.LogError($"处理随机播放切换失败: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 同步游戏的随机播放状态到 SMTC
+        /// </summary>
+        public void SyncShuffleState()
+        {
+            if (!_initialized || _musicService == null) return;
+            try
+            {
+                bool isShuffle = _musicService.IsShuffle;
+                _lastShuffleState = isShuffle;
+                SmtcBridge.SetShuffleActive(isShuffle);
+                _log.LogDebug($"同步随机播放状态: {isShuffle}");
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning($"同步随机播放状态失败: {ex.Message}");
+            }
         }
 
         /// <summary>
@@ -400,6 +499,8 @@ namespace ChillPatcher.UIFramework.Audio
             try
             {
                 SmtcBridge.OnButtonPressed -= OnButtonPressed;
+                SmtcBridge.OnPositionChangeRequested -= OnPositionChangeRequested;
+                SmtcBridge.OnShuffleChangeRequested -= OnShuffleChangeRequested;
                 CoverService.Instance.OnMusicCoverLoaded -= OnMusicCoverLoaded;
                 SmtcBridge.SetPlaybackStatus(SmtcBridge.PlaybackStatus.Closed);
                 SmtcBridge.Shutdown();


### PR DESCRIPTION
## 概要

增强 Windows SMTC（系统媒体传输控制）集成，新增三项功能：

- **进度条实时同步**：订阅 `PlayProgressEvent`（每秒触发），持续更新 SMTC 时间线位置。使用 PCM reader 的真实时长（`TotalFrames / SampleRate`）替代包含 30 分钟余量的 `AudioClip.length`
- **SMTC 拖动定位**：在原生 DLL 中注册 `PlaybackPositionChangeRequested` 事件，用户从 Windows 媒体浮窗拖动进度条时触发 `SetMusicProgress` 执行 seek
- **随机播放按钮双向同步**：扩展原生 DLL，通过 `ISystemMediaTransportControls2` 接口实现 `ShuffleEnabled` / `ShuffleEnabledChangeRequested`。SMTC 切换 → 调用游戏 `SetShuffle`；游戏侧变更 → 每秒检测并同步回 SMTC。新版 DLL 缺失时 graceful degradation，不影响核心功能

## 改动范围

| 层 | 文件 | 说明 |
|---|---|---|
| C++ 原生 DLL | `smtc_bridge.h` / `smtc_bridge.cpp` | 新增 `PlaybackPositionChangeRequested` 事件注册、shuffle API（`SmtcSetShuffleEnabled` 等） |
| C# P/Invoke | `SmtcBridge.cs` | 新增 shuffle 的 DLL import、回调委托、事件，所有 shuffle 调用带 try-catch 兼容旧 DLL |
| C# Service | `SystemMediaTransportService.cs` | 订阅 position/shuffle 回调、`SyncShuffleState`、`UpdateTimeline` 中检测游戏侧 shuffle 变更 |
| C# Patches | `SystemMediaTransport_Patches.cs` | 订阅 `PlayProgressEvent` 持续更新时间线 |
| C# Patches | `FacilityMusic_UpdateFacility_Patch.cs` | `PlayProgressEvent` 使用 PCM reader 真实时长 |