### PR TITLE
修复 Wallpaper Engine 桌面键盘输入穿透

### DIFF
--- a/Integration/SaveProfileService.cs
+++ b/Integration/SaveProfileService.cs
@@ -402,8 +402,8 @@ namespace ChillPatcher.Integration
                     // 检查文件名是否匹配任一 pattern（不含扩展名对比）
                     var nameNoExt = Path.GetFileNameWithoutExtension(fileName);
                     bool match = patterns.Any(p =>
-                        fileName.Contains(p, StringComparison.OrdinalIgnoreCase)
-                        || nameNoExt.Contains(p, StringComparison.OrdinalIgnoreCase));
+                        fileName.IndexOf(p, StringComparison.OrdinalIgnoreCase) >= 0
+                        || nameNoExt.IndexOf(p, StringComparison.OrdinalIgnoreCase) >= 0);
                     if (!match) continue;
                 }
 

--- a/Patches/KeyboardHookPatch.cs
+++ b/Patches/KeyboardHookPatch.cs
@@ -419,7 +419,13 @@ namespace ChillPatcher.Patches
                         return (IntPtr)1; // 拦截 F6
                     }
 
-                    // Ctrl 组合键（剪贴板操作）—— 与模式无关，仅在 UIToolkit TextField 获焦时拦截
+                    // 桌面模式：尽早放行所有按键，让系统和桌面应用完整接收键盘事件。
+                    if (!isGameMode)
+                    {
+                        return CallNextHookEx(hookId, nCode, wParam, lParam);
+                    }
+
+                    // Ctrl 组合键（剪贴板操作）—— 仅在 UIToolkit TextField 获焦时拦截
                     if (_ctrlHeld && UIToolkitInputDispatcher.IsUIToolkitTextFieldFocused)
                     {
                         if (vkCode == 0x56) // Ctrl+V: 粘贴
@@ -452,17 +458,18 @@ namespace ChillPatcher.Patches
                         }
                     }
 
-                    // 桌面模式：不拦截任何输入，让系统处理
-                    if (!isGameMode)
-                    {
-                        return CallNextHookEx(hookId, nCode, wParam, lParam);
-                    }
-
                     // 游戏模式：检测是否在桌面（只在桌面激活时拦截输入到游戏）
                     bool isDesktop = IsDesktopActive();
 
                     if (isDesktop)
                     {
+                        // 只有游戏内输入控件真正获焦时才捕获桌面键盘事件。
+                        // 否则桌面文件重命名、搜索框、快捷键等会被低级钩子吞掉。
+                        if (!UIToolkitInputDispatcher.HasFocusedInputTarget)
+                        {
+                            return CallNextHookEx(hookId, nCode, wParam, lParam);
+                        }
+
                         if (useRime && rimeEngine != null)
                         {
                             // 使用Rime处理输入
@@ -926,6 +933,9 @@ namespace ChillPatcher.Patches
             {
                 inputQueue.Clear();
                 commitQueue.Clear();
+                navigationKeyQueue.Clear();
+                clipActionQueue.Clear();
+                _pendingPasteText = null;
             }
         }
         
@@ -1117,12 +1127,13 @@ namespace ChillPatcher.Patches
         {
             try
             {
+                int instanceId = __instance.GetInstanceID();
+                UIToolkitInputDispatcher.ReportTMPInputFieldFocus(instanceId, __instance.isFocused);
+
                 // UIToolkit TextField 获焦时，队列已被 UIToolkitInputDispatcher 消费，跳过 TMP 注入
                 if (UIToolkitInputDispatcher.IsUIToolkitTextFieldFocused)
                     return;
 
-                int instanceId = __instance.GetInstanceID();
-                
                 // 只在输入框激活且获得焦点时注入
                 if (!__instance.isFocused)
                 {

--- a/UIToolkitInputDispatcher.cs
+++ b/UIToolkitInputDispatcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using BepInEx.Logging;
 using ChillPatcher.Patches;
 using UnityEngine;
@@ -15,8 +16,19 @@ namespace ChillPatcher
     {
         private static ManualLogSource _log;
 
+        private static volatile bool _isUIToolkitTextFieldFocused;
+        private static volatile bool _isTMPInputFieldFocused;
+        private static readonly object _tmpFocusLock = new object();
+        private static readonly HashSet<int> _focusedTMPInputFields = new HashSet<int>();
+
         /// <summary>当前帧是否有 UIToolkit TextField 获焦</summary>
-        public static bool IsUIToolkitTextFieldFocused { get; private set; }
+        public static bool IsUIToolkitTextFieldFocused => _isUIToolkitTextFieldFocused;
+
+        /// <summary>当前是否有 UGUI TMP_InputField 获焦</summary>
+        public static bool IsTMPInputFieldFocused => _isTMPInputFieldFocused;
+
+        /// <summary>是否有 ChillPatcher 输入控件需要接收全局键盘钩子输入</summary>
+        public static bool HasFocusedInputTarget => _isUIToolkitTextFieldFocused || _isTMPInputFieldFocused;
 
         /// <summary>Rime Context 变化事件（主线程触发，JSON 数据或 "null"）</summary>
         public static event Action<string, string> OnImeContextChanged;
@@ -49,6 +61,22 @@ namespace ChillPatcher
         {
             if (_positionLocked) return;
             _lastTMPScreenRect = screenRect;
+        }
+
+        /// <summary>
+        /// 由 TMP_InputField_LateUpdate_Patch 每帧报告焦点状态，避免失焦后留下陈旧 true。
+        /// </summary>
+        public static void ReportTMPInputFieldFocus(int instanceId, bool focused)
+        {
+            lock (_tmpFocusLock)
+            {
+                if (focused)
+                    _focusedTMPInputFields.Add(instanceId);
+                else
+                    _focusedTMPInputFields.Remove(instanceId);
+
+                _isTMPInputFieldFocused = _focusedTMPInputFields.Count > 0;
+            }
         }
 
         /// <summary>
@@ -125,7 +153,7 @@ namespace ChillPatcher
         /// </summary>
         public static void Tick()
         {
-            IsUIToolkitTextFieldFocused = false;
+            _isUIToolkitTextFieldFocused = false;
             _currentFocusedTextField = null;
 
             if (!OneJSBridge.IsInitialized) return;
@@ -143,7 +171,7 @@ namespace ChillPatcher
                 var tf = FindTextField(focused);
                 if (tf != null)
                 {
-                    IsUIToolkitTextFieldFocused = true;
+                    _isUIToolkitTextFieldFocused = true;
                     _currentFocusedTextField = tf;
 
                     // 缓存 TextField 的面板坐标（preedit 锁定期间不更新）


### PR DESCRIPTION
## 背景
在 Wallpaper Engine 桌面模式下，当前键盘钩子会过早消费桌面键盘事件，导致桌面、资源管理器或其他系统输入场景无法正常接收按键。

## 改动
- 桌面模式下默认放行键盘事件，保持系统桌面输入行为。
- 只有游戏内 UIToolkit/TMP 输入框真正获焦时，才把键盘输入交给 ChillPatcher 处理。
- 增加游戏内输入目标的焦点跟踪，避免未聚焦时误吞系统快捷键或文本输入。
- 将保存档筛选里的大小写不敏感匹配改为目标框架支持的写法，避免 net472 构建失败。

## 行为影响
- 桌面空白、桌面图标和其他系统窗口可以继续接收键盘事件。
- 游戏内文本输入框获焦时，Rime/剪贴板/导航键等输入逻辑仍由 ChillPatcher 接管。

## 验证
- `dotnet build ChillPatcher.sln -p:SteamLibraryRoot=D:\Steam`


## 关联 Issue

Closes #30

