### PR TITLE
修复 WE 桌面鼠标路由

### DIFF
--- a/ChillPatcher.csproj
+++ b/ChillPatcher.csproj
@@ -111,6 +111,9 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="WindowsBase" />
+    <Reference Include="UIAutomationClient" />
+    <Reference Include="UIAutomationTypes" />
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
   <PropertyGroup>

--- a/ChillPatcher.csproj
+++ b/ChillPatcher.csproj
@@ -111,9 +111,6 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="WindowsBase" />
-    <Reference Include="UIAutomationClient" />
-    <Reference Include="UIAutomationTypes" />
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
   <PropertyGroup>

--- a/Integration/SaveProfileService.cs
+++ b/Integration/SaveProfileService.cs
@@ -402,8 +402,8 @@ namespace ChillPatcher.Integration
                     // 检查文件名是否匹配任一 pattern（不含扩展名对比）
                     var nameNoExt = Path.GetFileNameWithoutExtension(fileName);
                     bool match = patterns.Any(p =>
-                        fileName.Contains(p, StringComparison.OrdinalIgnoreCase)
-                        || nameNoExt.Contains(p, StringComparison.OrdinalIgnoreCase));
+                        fileName.IndexOf(p, StringComparison.OrdinalIgnoreCase) >= 0
+                        || nameNoExt.IndexOf(p, StringComparison.OrdinalIgnoreCase) >= 0);
                     if (!match) continue;
                 }
 

--- a/Patches/KeyboardHookPatch.cs
+++ b/Patches/KeyboardHookPatch.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using Bulbul;
 using HarmonyLib;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -419,7 +420,13 @@ namespace ChillPatcher.Patches
                         return (IntPtr)1; // 拦截 F6
                     }
 
-                    // Ctrl 组合键（剪贴板操作）—— 与模式无关，仅在 UIToolkit TextField 获焦时拦截
+                    // 桌面模式：尽早放行所有按键，让系统和桌面应用完整接收键盘事件。
+                    if (!isGameMode)
+                    {
+                        return CallNextHookEx(hookId, nCode, wParam, lParam);
+                    }
+
+                    // Ctrl 组合键（剪贴板操作）—— 仅在 UIToolkit TextField 获焦时拦截
                     if (_ctrlHeld && UIToolkitInputDispatcher.IsUIToolkitTextFieldFocused)
                     {
                         if (vkCode == 0x56) // Ctrl+V: 粘贴
@@ -452,17 +459,18 @@ namespace ChillPatcher.Patches
                         }
                     }
 
-                    // 桌面模式：不拦截任何输入，让系统处理
-                    if (!isGameMode)
-                    {
-                        return CallNextHookEx(hookId, nCode, wParam, lParam);
-                    }
-
                     // 游戏模式：检测是否在桌面（只在桌面激活时拦截输入到游戏）
                     bool isDesktop = IsDesktopActive();
 
                     if (isDesktop)
                     {
+                        // 只有游戏内输入控件真正获焦时才捕获桌面键盘事件。
+                        // 否则桌面文件重命名、搜索框、快捷键等会被低级钩子吞掉。
+                        if (!UIToolkitInputDispatcher.HasFocusedInputTarget)
+                        {
+                            return CallNextHookEx(hookId, nCode, wParam, lParam);
+                        }
+
                         if (useRime && rimeEngine != null)
                         {
                             // 使用Rime处理输入
@@ -926,6 +934,9 @@ namespace ChillPatcher.Patches
             {
                 inputQueue.Clear();
                 commitQueue.Clear();
+                navigationKeyQueue.Clear();
+                clipActionQueue.Clear();
+                _pendingPasteText = null;
             }
         }
         
@@ -1078,6 +1089,38 @@ namespace ChillPatcher.Patches
     }
 
     /// <summary>
+    /// 当 OneJS UI 或桌面图标已经消费鼠标事件时，清空 UGUI raycast，
+    /// 避免同一次点击继续冒泡到 WE 内的游戏 UI。
+    /// </summary>
+    [HarmonyPatch(typeof(EventSystem), "RaycastAll")]
+    public class EventSystem_RaycastAll_Patch
+    {
+        static void Postfix(List<RaycastResult> raycastResults)
+        {
+            if (UIToolkitEventBlocker.ShouldClearUnityRaycasts)
+                raycastResults?.Clear();
+        }
+    }
+
+    /// <summary>
+    /// 游戏角色点击不走 UGUI raycast。桌面图标已经消费鼠标时，
+    /// 这里阻止同一次点击继续触发游戏内角色互动。
+    /// </summary>
+    [HarmonyPatch(typeof(FacilityClickHeroine), "ReactionReady")]
+    public class FacilityClickHeroine_ReactionReady_DesktopMouse_Patch
+    {
+        [HarmonyPriority(Priority.First)]
+        static bool Prefix(ref bool __result)
+        {
+            if (!UIToolkitEventBlocker.ShouldBlockGameSceneMouse())
+                return true;
+
+            __result = false;
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Patch TMP_InputField 来注入键盘输入和显示Rime候选词
     /// 
     /// ✅ 使用 Publicizer 直接访问 KeyPressed 方法（消除反射开销）
@@ -1117,12 +1160,13 @@ namespace ChillPatcher.Patches
         {
             try
             {
+                int instanceId = __instance.GetInstanceID();
+                UIToolkitInputDispatcher.ReportTMPInputFieldFocus(instanceId, __instance.isFocused);
+
                 // UIToolkit TextField 获焦时，队列已被 UIToolkitInputDispatcher 消费，跳过 TMP 注入
                 if (UIToolkitInputDispatcher.IsUIToolkitTextFieldFocused)
                     return;
 
-                int instanceId = __instance.GetInstanceID();
-                
                 // 只在输入框激活且获得焦点时注入
                 if (!__instance.isFocused)
                 {

--- a/UIToolkitEventBlocker.cs
+++ b/UIToolkitEventBlocker.cs
@@ -1,5 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows.Automation;
 using OneJS;
 using OneJS.Dom;
 using UnityEngine;
@@ -36,6 +40,49 @@ namespace ChillPatcher
         /// <summary>当前帧是否正在拦截 UGUI</summary>
         public static bool IsBlocking { get; private set; }
 
+        /// <summary>当前鼠标按压是否从桌面图标/项目开始</summary>
+        public static bool IsDesktopItemBlocking { get; private set; }
+
+        /// <summary>是否应该清空本帧 Unity UI raycast 结果</summary>
+        public static bool ShouldClearUnityRaycasts => IsBlocking || IsDesktopItemBlocking;
+
+        /// <summary>是否应阻止游戏场景侧鼠标互动</summary>
+        public static bool ShouldBlockGameSceneMouse()
+        {
+            return UpdateDesktopItemCapture();
+        }
+
+        private static bool _wasMouseDown;
+        private static bool _desktopItemCaptureActive;
+
+        private static readonly HashSet<string> DesktopForegroundClasses = new HashSet<string>
+        {
+            "Progman",
+            "WorkerW",
+            "SHELLDLL_DefView",
+            "SysListView32",
+        };
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetCursorPos(out POINT lpPoint);
+
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct POINT
+        {
+            public int x;
+            public int y;
+        }
+
         /// <summary>
         /// 每帧在 EventSystem.Update 之前调用。
         /// 检测鼠标是否在 UIToolkit 可交互元素上，设置 IsBlocking 标志。
@@ -43,6 +90,7 @@ namespace ChillPatcher
         public static void Update()
         {
             IsBlocking = false;
+            IsDesktopItemBlocking = UpdateDesktopItemCapture();
 
             if (!OneJSBridge.IsInitialized)
                 return;
@@ -75,9 +123,74 @@ namespace ChillPatcher
                 if (HasInteractiveAncestor(picked, rootVE, document, out _))
                 {
                     IsBlocking = true;
+                    IsDesktopItemBlocking = false;
                     break;
                 }
             }
+        }
+
+        private static bool UpdateDesktopItemCapture()
+        {
+            if (!PluginConfig.EnableWallpaperEngineMode.Value)
+                return false;
+
+            bool mouseDown = IsPrimaryMouseDown();
+            if (!mouseDown)
+            {
+                _wasMouseDown = false;
+                _desktopItemCaptureActive = false;
+                return false;
+            }
+
+            if (!_wasMouseDown)
+            {
+                _desktopItemCaptureActive =
+                    IsDesktopForegroundWindow(GetForegroundWindow())
+                    && IsDesktopListItemUnderCursor();
+            }
+
+            _wasMouseDown = true;
+            return _desktopItemCaptureActive;
+        }
+
+        private static bool IsPrimaryMouseDown()
+        {
+            return (GetAsyncKeyState(0x01) & 0x8000) != 0;
+        }
+
+        private static bool IsDesktopForegroundWindow(IntPtr hWnd)
+        {
+            if (hWnd == IntPtr.Zero)
+                return false;
+
+            return DesktopForegroundClasses.Contains(GetWindowClassName(hWnd));
+        }
+
+        private static bool IsDesktopListItemUnderCursor()
+        {
+            if (!GetCursorPos(out var point))
+                return false;
+
+            try
+            {
+                var element = AutomationElement.FromPoint(
+                    new System.Windows.Point(point.x, point.y));
+                if (element == null)
+                    return false;
+
+                return element.Current.ControlType == ControlType.ListItem;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string GetWindowClassName(IntPtr hWnd)
+        {
+            var className = new StringBuilder(256);
+            GetClassName(hWnd, className, className.Capacity);
+            return className.ToString();
         }
 
         #region DOM 交互检测

--- a/UIToolkitEventBlocker.cs
+++ b/UIToolkitEventBlocker.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Windows.Automation;
 using OneJS;
 using OneJS.Dom;
 using UnityEngine;
@@ -54,6 +53,8 @@ namespace ChillPatcher
 
         private static bool _wasMouseDown;
         private static bool _desktopItemCaptureActive;
+        private static POINT _mouseDownPoint;
+        private const int DesktopDragReleaseThresholdPixels = 6;
 
         private static readonly HashSet<string> DesktopForegroundClasses = new HashSet<string>
         {
@@ -74,13 +75,86 @@ namespace ChillPatcher
         private static extern bool GetCursorPos(out POINT lpPoint);
 
         [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ScreenToClient(IntPtr hWnd, ref POINT lpPoint);
+
+        [DllImport("user32.dll")]
         private static extern short GetAsyncKeyState(int vKey);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr FindWindowEx(IntPtr hWndParent, IntPtr hWndChildAfter,
+            string lpszClass, string lpszWindow);
+
+        [DllImport("user32.dll")]
+        private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr OpenProcess(int dwDesiredAccess,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwProcessId);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr VirtualAllocEx(IntPtr hProcess, IntPtr lpAddress,
+            int dwSize, int flAllocationType, int flProtect);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr lpAddress,
+            int dwSize, int dwFreeType);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool WriteProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress,
+            byte[] lpBuffer, int nSize, out IntPtr lpNumberOfBytesWritten);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ReadProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress,
+            byte[] lpBuffer, int nSize, out IntPtr lpNumberOfBytesRead);
+
+        [DllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle(IntPtr hObject);
+
+        private const int LVM_FIRST = 0x1000;
+        private const int LVM_HITTEST = LVM_FIRST + 18;
+        private const int LVHT_ONITEMICON = 0x0002;
+        private const int LVHT_ONITEMLABEL = 0x0004;
+        private const int LVHT_ONITEMSTATEICON = 0x0008;
+        private const int LVHT_ONITEM = LVHT_ONITEMICON | LVHT_ONITEMLABEL | LVHT_ONITEMSTATEICON;
+
+        private const int PROCESS_QUERY_INFORMATION = 0x0400;
+        private const int PROCESS_VM_OPERATION = 0x0008;
+        private const int PROCESS_VM_READ = 0x0010;
+        private const int PROCESS_VM_WRITE = 0x0020;
+        private const int DESKTOP_LISTVIEW_PROCESS_ACCESS =
+            PROCESS_QUERY_INFORMATION | PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_VM_WRITE;
+
+        private const int MEM_COMMIT = 0x1000;
+        private const int MEM_RESERVE = 0x2000;
+        private const int MEM_RELEASE = 0x8000;
+        private const int PAGE_READWRITE = 0x04;
 
         [StructLayout(LayoutKind.Sequential)]
         private struct POINT
         {
             public int x;
             public int y;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct LVHITTESTINFO
+        {
+            public POINT pt;
+            public int flags;
+            public int iItem;
+            public int iSubItem;
+            public int iGroup;
         }
 
         /// <summary>
@@ -124,7 +198,7 @@ namespace ChillPatcher
                 {
                     IsBlocking = true;
                     IsDesktopItemBlocking = false;
-                    break;
+                    return;
                 }
             }
         }
@@ -144,9 +218,16 @@ namespace ChillPatcher
 
             if (!_wasMouseDown)
             {
+                if (!GetCursorPos(out _mouseDownPoint))
+                    _mouseDownPoint = default;
+
                 _desktopItemCaptureActive =
                     IsDesktopForegroundWindow(GetForegroundWindow())
                     && IsDesktopListItemUnderCursor();
+            }
+            else if (_desktopItemCaptureActive && HasMouseMovedPastDesktopDragThreshold())
+            {
+                _desktopItemCaptureActive = false;
             }
 
             _wasMouseDown = true;
@@ -158,6 +239,22 @@ namespace ChillPatcher
             return (GetAsyncKeyState(0x01) & 0x8000) != 0;
         }
 
+        private static bool HasMouseMovedPastDesktopDragThreshold()
+        {
+            if (!GetCursorPos(out var currentPoint))
+                return false;
+
+            int dx = currentPoint.x - _mouseDownPoint.x;
+            int dy = currentPoint.y - _mouseDownPoint.y;
+            int threshold = DesktopDragReleaseThresholdPixels;
+            return dx * dx + dy * dy > threshold * threshold;
+        }
+
+        public static bool IsDesktopForegroundActive()
+        {
+            return IsDesktopForegroundWindow(GetForegroundWindow());
+        }
+
         private static bool IsDesktopForegroundWindow(IntPtr hWnd)
         {
             if (hWnd == IntPtr.Zero)
@@ -166,23 +263,126 @@ namespace ChillPatcher
             return DesktopForegroundClasses.Contains(GetWindowClassName(hWnd));
         }
 
-        private static bool IsDesktopListItemUnderCursor()
+        public static bool IsDesktopListItemUnderCursor()
         {
-            if (!GetCursorPos(out var point))
+            if (!GetCursorPos(out var screenPoint))
                 return false;
+
+            var listView = FindDesktopListViewWindow();
+            if (listView == IntPtr.Zero)
+                return false;
+
+            var clientPoint = screenPoint;
+            if (!ScreenToClient(listView, ref clientPoint))
+                return false;
+
+            return TryDesktopListViewHitTest(listView, clientPoint, out var hit)
+                && hit.iItem >= 0
+                && (hit.flags & LVHT_ONITEM) != 0;
+        }
+
+        public static IntPtr GetDesktopListViewWindow()
+        {
+            return FindDesktopListViewWindow();
+        }
+
+        private static IntPtr FindDesktopListViewWindow()
+        {
+            var progman = FindWindow("Progman", null);
+            var listView = FindDesktopListViewWindowIn(progman);
+            if (listView != IntPtr.Zero)
+                return listView;
+
+            var worker = IntPtr.Zero;
+            while ((worker = FindWindowEx(IntPtr.Zero, worker, "WorkerW", null)) != IntPtr.Zero)
+            {
+                listView = FindDesktopListViewWindowIn(worker);
+                if (listView != IntPtr.Zero)
+                    return listView;
+            }
+
+            return IntPtr.Zero;
+        }
+
+        private static IntPtr FindDesktopListViewWindowIn(IntPtr parent)
+        {
+            if (parent == IntPtr.Zero)
+                return IntPtr.Zero;
+
+            var defView = FindWindowEx(parent, IntPtr.Zero, "SHELLDLL_DefView", null);
+            if (defView == IntPtr.Zero)
+                return IntPtr.Zero;
+
+            return FindWindowEx(defView, IntPtr.Zero, "SysListView32", null);
+        }
+
+        private static bool TryDesktopListViewHitTest(IntPtr listView, POINT clientPoint,
+            out LVHITTESTINFO hit)
+        {
+            hit = new LVHITTESTINFO
+            {
+                pt = clientPoint,
+                flags = 0,
+                iItem = -1,
+                iSubItem = 0,
+                iGroup = 0,
+            };
+
+            GetWindowThreadProcessId(listView, out var processId);
+            if (processId == 0)
+                return false;
+
+            var process = OpenProcess(DESKTOP_LISTVIEW_PROCESS_ACCESS, false, processId);
+            if (process == IntPtr.Zero)
+                return false;
+
+            var size = Marshal.SizeOf(typeof(LVHITTESTINFO));
+            var remoteBuffer = IntPtr.Zero;
+            var localBuffer = IntPtr.Zero;
 
             try
             {
-                var element = AutomationElement.FromPoint(
-                    new System.Windows.Point(point.x, point.y));
-                if (element == null)
+                remoteBuffer = VirtualAllocEx(process, IntPtr.Zero, size,
+                    MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+                if (remoteBuffer == IntPtr.Zero)
                     return false;
 
-                return element.Current.ControlType == ControlType.ListItem;
+                localBuffer = Marshal.AllocHGlobal(size);
+                Marshal.StructureToPtr(hit, localBuffer, false);
+
+                var bytes = new byte[size];
+                Marshal.Copy(localBuffer, bytes, 0, size);
+
+                if (!WriteProcessMemory(process, remoteBuffer, bytes, size, out var written)
+                    || written.ToInt64() != size)
+                {
+                    return false;
+                }
+
+                SendMessage(listView, LVM_HITTEST, IntPtr.Zero, remoteBuffer);
+
+                var result = new byte[size];
+                if (!ReadProcessMemory(process, remoteBuffer, result, size, out var read)
+                    || read.ToInt64() != size)
+                {
+                    return false;
+                }
+
+                Marshal.Copy(result, 0, localBuffer, size);
+                hit = (LVHITTESTINFO)Marshal.PtrToStructure(localBuffer, typeof(LVHITTESTINFO));
+                return true;
             }
             catch
             {
                 return false;
+            }
+            finally
+            {
+                if (localBuffer != IntPtr.Zero)
+                    Marshal.FreeHGlobal(localBuffer);
+                if (remoteBuffer != IntPtr.Zero)
+                    VirtualFreeEx(process, remoteBuffer, 0, MEM_RELEASE);
+                CloseHandle(process);
             }
         }
 

--- a/UIToolkitInputDispatcher.cs
+++ b/UIToolkitInputDispatcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using BepInEx.Logging;
 using ChillPatcher.Patches;
 using UnityEngine;
@@ -15,8 +16,19 @@ namespace ChillPatcher
     {
         private static ManualLogSource _log;
 
+        private static volatile bool _isUIToolkitTextFieldFocused;
+        private static volatile bool _isTMPInputFieldFocused;
+        private static readonly object _tmpFocusLock = new object();
+        private static readonly HashSet<int> _focusedTMPInputFields = new HashSet<int>();
+
         /// <summary>当前帧是否有 UIToolkit TextField 获焦</summary>
-        public static bool IsUIToolkitTextFieldFocused { get; private set; }
+        public static bool IsUIToolkitTextFieldFocused => _isUIToolkitTextFieldFocused;
+
+        /// <summary>当前是否有 UGUI TMP_InputField 获焦</summary>
+        public static bool IsTMPInputFieldFocused => _isTMPInputFieldFocused;
+
+        /// <summary>是否有 ChillPatcher 输入控件需要接收全局键盘钩子输入</summary>
+        public static bool HasFocusedInputTarget => _isUIToolkitTextFieldFocused || _isTMPInputFieldFocused;
 
         /// <summary>Rime Context 变化事件（主线程触发，JSON 数据或 "null"）</summary>
         public static event Action<string, string> OnImeContextChanged;
@@ -49,6 +61,22 @@ namespace ChillPatcher
         {
             if (_positionLocked) return;
             _lastTMPScreenRect = screenRect;
+        }
+
+        /// <summary>
+        /// 由 TMP_InputField_LateUpdate_Patch 每帧报告焦点状态，避免失焦后留下陈旧 true。
+        /// </summary>
+        public static void ReportTMPInputFieldFocus(int instanceId, bool focused)
+        {
+            lock (_tmpFocusLock)
+            {
+                if (focused)
+                    _focusedTMPInputFields.Add(instanceId);
+                else
+                    _focusedTMPInputFields.Remove(instanceId);
+
+                _isTMPInputFieldFocused = _focusedTMPInputFields.Count > 0;
+            }
         }
 
         /// <summary>
@@ -125,7 +153,7 @@ namespace ChillPatcher
         /// </summary>
         public static void Tick()
         {
-            IsUIToolkitTextFieldFocused = false;
+            _isUIToolkitTextFieldFocused = false;
             _currentFocusedTextField = null;
 
             if (!OneJSBridge.IsInitialized) return;
@@ -143,7 +171,7 @@ namespace ChillPatcher
                 var tf = FindTextField(focused);
                 if (tf != null)
                 {
-                    IsUIToolkitTextFieldFocused = true;
+                    _isUIToolkitTextFieldFocused = true;
                     _currentFocusedTextField = tf;
 
                     // 缓存 TextField 的面板坐标（preedit 锁定期间不更新）


### PR DESCRIPTION
## 概要
- 将桌面图标命中检测从 UI Automation 改为 Explorer 桌面 `SysListView32` 的原生命中测试。
- 移除会干扰桌面框选/可见性的桌面鼠标钩子实验。
- 保留当前接受的行为：桌面图标优先，桌面空白框选保持可用；游戏内 UI 与桌面空白在部分场景可能同时响应。
- 补上 net472 下 `SaveProfileService` 的 `StringComparison` 兼容修复，使该分支可以独立基于 `main` 构建。

## 说明
- 该 PR 已重新基于 `main` 创建，不再依赖 #74 的分支作为 base。
- 两个 PR 都以 `main` 为 base；重复的 net472 兼容修复在其中一个 PR 合并后会自然从另一个 PR 的 diff 中消失。

## 验证
- `dotnet build ChillPatcher.sln -p:SteamLibraryRoot=D:\Steam`
- 通过 Wallpaper Engine 控制命令重新加载壁纸，并检查 BepInEx 启动日志。