### PR TITLE
feat(installer): 添加中文界面和可选旧数据清理

### DIFF
--- a/scripts/installer/OmniMixPlayer.iss
+++ b/scripts/installer/OmniMixPlayer.iss
@@ -67,6 +67,7 @@ english.CleanupLogPrefix=Optional cleanup:
 english.ServiceUpdateFailed=Failed to update the OmniMixPlayerBackend service path. Check the setup log or run the installer as administrator.
 english.InvalidOldInstallDir=The selected previous installation directory is not recognized as an OmniMixPlayer installation:
 english.DeleteOldInstallFailed=Failed to completely delete the previous installation directory. Close programs using this directory and try again:
+english.CleanupPathFailed=Failed to remove selected cleanup data. Close OmniMixPlayer and try again:
 chinesesimplified.CleanupPageTitle=可选清理
 chinesesimplified.CleanupPageDescription=选择需要清理的旧版 OmniMixPlayer 数据
 chinesesimplified.CleanupPageSubCaption=所有选项默认不勾选。请只选择你明确需要删除的数据。
@@ -87,6 +88,7 @@ chinesesimplified.CleanupLogPrefix=可选清理：
 chinesesimplified.ServiceUpdateFailed=OmniMixPlayerBackend 服务路径更新失败。请检查安装日志，或以管理员身份重新运行安装程序。
 chinesesimplified.InvalidOldInstallDir=所选目录不是可识别的 OmniMixPlayer 安装目录：
 chinesesimplified.DeleteOldInstallFailed=无法完整删除原安装目录。请关闭正在使用该目录的程序后重试：
+chinesesimplified.CleanupPathFailed=无法删除所选清理数据。请关闭 OmniMixPlayer 后重试：
 
 [Files]
 ; ═══ 所有可执行文件和 DLL (排除 VC 运行库，它单独处理) ═══
@@ -128,8 +130,8 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 
 [UninstallRun]
 ; 卸载前停止并删除服务
-Filename: "sc.exe"; Parameters: "stop {#MyServiceName}"; Flags: runhidden; RunOnceId: "StopOmniMixPlayerBackend"
-Filename: "sc.exe"; Parameters: "delete {#MyServiceName}"; Flags: runhidden; RunOnceId: "DeleteOmniMixPlayerBackend"
+Filename: "{sys}\sc.exe"; Parameters: "stop {#MyServiceName}"; Flags: runhidden; RunOnceId: "StopOmniMixPlayerBackend"; Check: ShouldRemoveServiceOnUninstall
+Filename: "{sys}\sc.exe"; Parameters: "delete {#MyServiceName}"; Flags: runhidden; RunOnceId: "DeleteOmniMixPlayerBackend"; Check: ShouldRemoveServiceOnUninstall
 
 ; ═════════════════════════════════════════════════════════════════════════════
 ; [Code] 部分 — Pascal 脚本
@@ -142,7 +144,7 @@ var
   OldInstallDirPage: TInputDirWizardPage;
   OldServiceDir: string;
   PreviousInstallDir: string;
-  CleanupConfirmed: Boolean;
+  ConfirmedCleanupSignature: string;
   CleanupFailure: string;
   ApprovedOldInstallDir: string;
 
@@ -220,6 +222,15 @@ begin
   Result := StripTrailingSlash(RemoveQuotes(Result));
 end;
 
+function ShouldRemoveServiceOnUninstall(): Boolean;
+begin
+  Result :=
+    CompareText(
+      ReadServiceInstallDir(),
+      StripTrailingSlash(ExpandConstant('{app}'))
+    ) = 0;
+end;
+
 function IsKnownInstallDir(const BaseDir: string): Boolean;
 var
   Normalized: string;
@@ -252,6 +263,26 @@ begin
       Log(CustomMessage('CleanupLogPrefix') + ' deleted directory ' + DirName)
     else
       Log(CustomMessage('CleanupLogPrefix') + ' failed to delete directory ' + DirName);
+  end;
+end;
+
+procedure DeleteFileRequired(const FileName: string);
+begin
+  if FileExists(FileName) and (not DeleteFile(FileName)) then
+  begin
+    Log(CustomMessage('CleanupLogPrefix') + ' failed to delete required file ' + FileName);
+    if CleanupFailure = '' then
+      CleanupFailure := CustomMessage('CleanupPathFailed') + #13#10 + FileName;
+  end;
+end;
+
+procedure DeleteTreeRequired(const DirName: string);
+begin
+  if DirExists(DirName) and (not DelTree(DirName, True, True, True)) then
+  begin
+    Log(CustomMessage('CleanupLogPrefix') + ' failed to delete required directory ' + DirName);
+    if CleanupFailure = '' then
+      CleanupFailure := CustomMessage('CleanupPathFailed') + #13#10 + DirName;
   end;
 end;
 
@@ -299,9 +330,9 @@ begin
 
   if CleanupPage.Values[3] then
   begin
-    DeleteFileLogged(ModulesDir + 'com.chillpatcher.qqmusic\data\qqmusic_cookie.json');
-    DeleteFileLogged(ModulesDir + 'com.chillpatcher.bilibili\data\bilibili_session.json');
-    DeleteFileLogged(ModulesDir + 'com.chillpatcher.spotify\data\spotify_session.json');
+    DeleteFileRequired(ModulesDir + 'com.chillpatcher.qqmusic\data\qqmusic_cookie.json');
+    DeleteFileRequired(ModulesDir + 'com.chillpatcher.bilibili\data\bilibili_session.json');
+    DeleteFileRequired(ModulesDir + 'com.chillpatcher.spotify\data\spotify_session.json');
   end;
 end;
 
@@ -348,8 +379,8 @@ begin
 
   if CleanupPage.Values[3] then
   begin
-    DeleteTreeLogged(ExpandConstant('{localappdata}\go-musicfox'));
-    DeleteTreeLogged(ExpandConstant('{sys}\config\systemprofile\AppData\Local\go-musicfox'));
+    DeleteTreeRequired(ExpandConstant('{localappdata}\go-musicfox'));
+    DeleteTreeRequired(ExpandConstant('{sys}\config\systemprofile\AppData\Local\go-musicfox'));
   end;
 
   if CleanupPage.Values[4] then
@@ -361,7 +392,7 @@ var
   PageSubCaption: string;
   DetectedInstallDir: string;
 begin
-  CleanupConfirmed := False;
+  ConfirmedCleanupSignature := '';
   CleanupFailure := '';
   ApprovedOldInstallDir := '';
   OldServiceDir := ReadServiceInstallDir();
@@ -412,9 +443,24 @@ begin
   CleanupPage.Add(CustomMessage('CleanupIntegrationData'));
 end;
 
+function GetCleanupSignature(): string;
+var
+  I: Integer;
+begin
+  Result := Lowercase(StripTrailingSlash(OldInstallDirPage.Values[0])) + '|';
+  for I := 0 to 4 do
+  begin
+    if CleanupPage.Values[I] then
+      Result := Result + '1'
+    else
+      Result := Result + '0';
+  end;
+end;
+
 function NextButtonClick(CurPageID: Integer): Boolean;
 var
   HasDestructiveSelection: Boolean;
+  CleanupSignature: string;
 begin
   Result := True;
   if CurPageID <> CleanupPage.ID then
@@ -426,7 +472,9 @@ begin
     CleanupPage.Values[3] or
     CleanupPage.Values[4];
 
-  if HasDestructiveSelection and not CleanupConfirmed then
+  CleanupSignature := GetCleanupSignature();
+  if HasDestructiveSelection and
+     (CompareText(CleanupSignature, ConfirmedCleanupSignature) <> 0) then
   begin
     Result :=
       MsgBox(
@@ -434,7 +482,10 @@ begin
         mbConfirmation,
         MB_YESNO
       ) = IDYES;
-    CleanupConfirmed := Result;
+    if Result then
+      ConfirmedCleanupSignature := CleanupSignature
+    else
+      ConfirmedCleanupSignature := '';
   end;
 end;
 
@@ -482,7 +533,7 @@ function ServiceExists(ServiceName: string): Boolean;
 var
   ResultCode: Integer;
 begin
-  Exec('sc.exe', 'query "' + ServiceName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Exec(ExpandConstant('{sys}\sc.exe'), 'query "' + ServiceName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
   Result := (ResultCode = 0);
 end;
 
@@ -497,7 +548,7 @@ begin
   begin
     Result :=
       Exec(
-        'sc.exe',
+        ExpandConstant('{sys}\sc.exe'),
         'stop "' + ServiceName + '"',
         '',
         SW_HIDE,
@@ -516,7 +567,8 @@ var
 begin
   TempFile := ExpandConstant('{tmp}\process_check.txt');
   // 使用 tasklist 检查进程
-  Exec('cmd.exe', '/c tasklist /FI "IMAGENAME eq ' + ProcName + '" /NH > "' + TempFile + '"',
+  Exec(ExpandConstant('{cmd}'), '/c ""' + ExpandConstant('{sys}\tasklist.exe') +
+       '" /FI "IMAGENAME eq ' + ProcName + '" /NH > "' + TempFile + '""',
        '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
   Result := FileExists(TempFile) and (Pos(ProcName, GetFileContents(TempFile)) > 0);
   if FileExists(TempFile) then
@@ -530,7 +582,7 @@ var
 begin
   if IsProcessRunning(ProcName) then
   begin
-    Exec('taskkill', '/F /IM "' + ProcName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM "' + ProcName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     // 等待进程退出
     Sleep(2000);
   end;
@@ -587,7 +639,7 @@ begin
     begin
       ServiceUpdated :=
         Exec(
-          'sc.exe',
+          ExpandConstant('{sys}\sc.exe'),
           'config "{#MyServiceName}" binPath= "' + BackendPath + '" start= demand',
           '',
           SW_HIDE,
@@ -601,7 +653,7 @@ begin
     begin
       ServiceUpdated :=
         Exec(
-          'sc.exe',
+          ExpandConstant('{sys}\sc.exe'),
           'create "{#MyServiceName}" binPath= "' + BackendPath + '" start= demand',
           '',
           SW_HIDE,
@@ -615,7 +667,7 @@ begin
     if ServiceUpdated then
     begin
       // 配置 DACL：允许 Authenticated Users (AU) 无提权启停服务
-      Exec('sc.exe', 'sdset {#MyServiceName} D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CCDCRPWP;;;AU)',
+      Exec(ExpandConstant('{sys}\sc.exe'), 'sdset {#MyServiceName} D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CCDCRPWP;;;AU)',
           '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
       Log('服务 DACL 配置完成');
     end

--- a/scripts/installer/OmniMixPlayer.iss
+++ b/scripts/installer/OmniMixPlayer.iss
@@ -26,9 +26,10 @@ UninstallDisplayIcon={app}\{#MyAppExeName}
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 DisableProgramGroupPage=yes
-; Uncomment the following line to run in non administrative install mode (install for current user only).
-;PrivilegesRequired=lowest
-PrivilegesRequiredOverridesAllowed=dialog
+DisableDirPage=no
+UsePreviousAppDir=yes
+; Windows service installation and migration require elevation.
+PrivilegesRequired=admin
 OutputDir=G:/Csharp/Chill/release
 OutputBaseFilename=OmniMixPlayer_V3.0.2_installer
 Compression=lzma2/ultra64
@@ -56,8 +57,10 @@ english.CleanupLoginData=Remove music service sessions stored in default locatio
 english.CleanupIntegrationData=Remove game integration records, downloaded mod copies and backups (installed game mods remain, but automatic uninstall/restore may no longer work)
 english.CleanupConfirm=The selected cleanup options may remove settings, library data, login sessions or integration backups.%n%nThis operation cannot be undone. Continue?
 english.CleanupOldInstall=Previous backend directory detected:
+english.CleanupPreviousInstall=Previous installer directory detected:
 english.CleanupNoOldInstall=No previous backend directory was detected. Cleanup will apply to the selected installation directory and user profile data.
 english.CleanupLogPrefix=Optional cleanup:
+english.ServiceUpdateFailed=Failed to update the OmniMixPlayerBackend service path. Check the setup log or run the installer as administrator.
 chinesesimplified.CleanupPageTitle=可选清理
 chinesesimplified.CleanupPageDescription=选择需要清理的旧版 OmniMixPlayer 数据
 chinesesimplified.CleanupPageSubCaption=所有选项默认不勾选。请只选择你明确需要删除的数据。
@@ -68,8 +71,10 @@ chinesesimplified.CleanupLoginData=删除默认位置中的音乐源登录状态
 chinesesimplified.CleanupIntegrationData=删除游戏集成记录、已下载的 Mod 副本和备份（不会卸载游戏中的 Mod，但之后可能无法自动卸载或恢复）
 chinesesimplified.CleanupConfirm=所选清理项可能删除设置、曲库、登录状态或游戏集成备份。%n%n此操作无法撤销，是否继续？
 chinesesimplified.CleanupOldInstall=检测到旧后端目录：
+chinesesimplified.CleanupPreviousInstall=检测到上一次安装目录：
 chinesesimplified.CleanupNoOldInstall=未检测到旧后端目录。清理将作用于当前选择的安装目录和用户配置目录。
 chinesesimplified.CleanupLogPrefix=可选清理：
+chinesesimplified.ServiceUpdateFailed=OmniMixPlayerBackend 服务路径更新失败。请检查安装日志，或以管理员身份重新运行安装程序。
 
 [Files]
 ; ═══ 所有可执行文件和 DLL (排除 VC 运行库，它单独处理) ═══
@@ -122,12 +127,13 @@ Filename: "sc.exe"; Parameters: "delete {#MyServiceName}"; Flags: runhidden; Run
 
 var
   CleanupPage: TInputOptionWizardPage;
-  OldInstallDir: string;
+  OldServiceDir: string;
+  PreviousInstallDir: string;
   CleanupConfirmed: Boolean;
 
 const
   ServiceRegistryPath = 'SYSTEM\CurrentControlSet\Services\{#MyServiceName}';
-  UninstallRegistryPath = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}_is1';
+  UninstallRegistryPath = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}}_is1';
 
 // ── 字符串和路径辅助函数 ──
 function StripTrailingSlash(Value: string): string;
@@ -275,8 +281,11 @@ var
 begin
   CurrentInstallDir := StripTrailingSlash(WizardDirValue());
 
-  CleanupInstallLocation(OldInstallDir);
-  if CompareText(OldInstallDir, CurrentInstallDir) <> 0 then
+  CleanupInstallLocation(OldServiceDir);
+  if CompareText(PreviousInstallDir, OldServiceDir) <> 0 then
+    CleanupInstallLocation(PreviousInstallDir);
+  if (CompareText(CurrentInstallDir, OldServiceDir) <> 0) and
+     (CompareText(CurrentInstallDir, PreviousInstallDir) <> 0) then
     CleanupInstallLocation(CurrentInstallDir);
 
   GuiDataDir := ExpandConstant('{userappdata}\com.omnimixplayer\omnimix_gui');
@@ -291,7 +300,7 @@ begin
     DeleteFileLogged(AddBackslash(GuiDataDir) + 'shared_preferences.json');
 
   if CleanupPage.Values[3] then
-    DeleteFileOrTreeLogged(ExpandConstant('{localappdata}\go-musicfox\cookie'));
+    DeleteTreeLogged(ExpandConstant('{localappdata}\go-musicfox'));
 
   if CleanupPage.Values[4] then
     DeleteTreeLogged(ExpandConstant('{localappdata}\OmniMixPlayer\mod_manager'));
@@ -302,14 +311,22 @@ var
   PageSubCaption: string;
 begin
   CleanupConfirmed := False;
-  OldInstallDir := ReadServiceInstallDir();
-  if OldInstallDir = '' then
-    OldInstallDir := ReadRegisteredInstallDir();
+  OldServiceDir := ReadServiceInstallDir();
+  PreviousInstallDir := ReadRegisteredInstallDir();
 
-  if OldInstallDir <> '' then
-    PageSubCaption :=
-      CustomMessage('CleanupPageSubCaption') + #13#10 + #13#10 +
-      CustomMessage('CleanupOldInstall') + #13#10 + OldInstallDir
+  if (OldServiceDir <> '') or (PreviousInstallDir <> '') then
+  begin
+    PageSubCaption := CustomMessage('CleanupPageSubCaption');
+    if OldServiceDir <> '' then
+      PageSubCaption :=
+        PageSubCaption + #13#10 + #13#10 +
+        CustomMessage('CleanupOldInstall') + #13#10 + OldServiceDir;
+    if (PreviousInstallDir <> '') and
+       (CompareText(PreviousInstallDir, OldServiceDir) <> 0) then
+      PageSubCaption :=
+        PageSubCaption + #13#10 + #13#10 +
+        CustomMessage('CleanupPreviousInstall') + #13#10 + PreviousInstallDir;
+  end
   else
     PageSubCaption :=
       CustomMessage('CleanupPageSubCaption') + #13#10 + #13#10 +
@@ -405,20 +422,24 @@ begin
 end;
 
 // ── 检查并停止服务 ──
-function StopAndRemoveService(ServiceName: string): Boolean;
+function StopService(ServiceName: string): Boolean;
 var
   ResultCode: Integer;
 begin
   Result := True;
-  
-  // 停止服务
+
   if ServiceExists(ServiceName) then
   begin
-    Exec('sc.exe', 'stop "' + ServiceName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-    // 等待服务停止（最多等 30 秒）
-    Sleep(3000);
-    // 删除服务，安装后会重新创建
-    Exec('sc.exe', 'delete "' + ServiceName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Result :=
+      Exec(
+        'sc.exe',
+        'stop "' + ServiceName + '"',
+        '',
+        SW_HIDE,
+        ewWaitUntilTerminated,
+        ResultCode
+      ) and ((ResultCode = 0) or (ResultCode = 1062));
+    Sleep(1500);
   end;
 end;
 
@@ -459,7 +480,8 @@ begin
   if ServiceExists('{#MyServiceName}') then
   begin
     Log('检测到 {#MyServiceName} 服务正在运行，正在停止...');
-    StopAndRemoveService('{#MyServiceName}');
+    if not StopService('{#MyServiceName}') then
+      Log('警告：停止 {#MyServiceName} 服务失败，将继续终止后端进程');
   end;
 
   // 2. 终止 GUI 进程
@@ -483,30 +505,62 @@ begin
   RunOptionalCleanup();
 end;
 
-// ── 安装完成后重新创建服务 ──
+// ── 安装完成后创建或更新服务 ──
 procedure CurStepChanged(CurStep: TSetupStep);
 var
   ResultCode: Integer;
   BackendPath: string;
+  ServiceUpdated: Boolean;
 begin
   if CurStep = ssPostInstall then
   begin
-    BackendPath := ExpandConstant('"{app}\{#MyAppBackendName}"');
-    
-    // 重新创建 Windows 服务 (手动启动)
-    if Exec('sc.exe', 'create {#MyServiceName} binPath= ' + BackendPath + ' start= demand',
-           '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+    BackendPath := ExpandConstant('{app}\{#MyAppBackendName}');
+
+    if ServiceExists('{#MyServiceName}') then
     begin
-      Log('服务 {#MyServiceName} 创建成功');
-      
+      ServiceUpdated :=
+        Exec(
+          'sc.exe',
+          'config "{#MyServiceName}" binPath= "' + BackendPath + '" start= demand',
+          '',
+          SW_HIDE,
+          ewWaitUntilTerminated,
+          ResultCode
+        ) and (ResultCode = 0);
+      if ServiceUpdated then
+        Log('服务 {#MyServiceName} 已更新到新路径：' + BackendPath);
+    end
+    else
+    begin
+      ServiceUpdated :=
+        Exec(
+          'sc.exe',
+          'create "{#MyServiceName}" binPath= "' + BackendPath + '" start= demand',
+          '',
+          SW_HIDE,
+          ewWaitUntilTerminated,
+          ResultCode
+        ) and (ResultCode = 0);
+      if ServiceUpdated then
+        Log('服务 {#MyServiceName} 创建成功：' + BackendPath);
+    end;
+
+    if ServiceUpdated then
+    begin
       // 配置 DACL：允许 Authenticated Users (AU) 无提权启停服务
       Exec('sc.exe', 'sdset {#MyServiceName} D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CCDCRPWP;;;AU)',
           '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-      
       Log('服务 DACL 配置完成');
     end
     else
-      Log('警告：服务 {#MyServiceName} 创建失败，请检查权限');
+    begin
+      Log('错误：服务 {#MyServiceName} 创建或更新失败，错误代码：' + IntToStr(ResultCode));
+      MsgBox(
+        CustomMessage('ServiceUpdateFailed'),
+        mbError,
+        MB_OK
+      );
+    end;
   end;
 end;
 

--- a/scripts/installer/OmniMixPlayer.iss
+++ b/scripts/installer/OmniMixPlayer.iss
@@ -50,6 +50,10 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 english.CleanupPageTitle=Optional cleanup
 english.CleanupPageDescription=Choose data left by previous OmniMixPlayer installations
 english.CleanupPageSubCaption=All options are disabled by default. Only select data you explicitly want to remove.
+english.OldInstallDirPageTitle=Previous installation directory
+english.OldInstallDirPageDescription=Select the previous OmniMixPlayer installation to remove
+english.OldInstallDirPageSubCaption=The detected directory is filled automatically. You can browse to another previous installation directory. The directory is only deleted when the deletion option is selected.
+english.OldInstallDirLabel=Previous installation directory:
 english.CleanupAudioCache=Clear rebuildable audio and image caches
 english.CleanupGuiSettings=Reset desktop GUI preferences (theme, volume, shortcuts, window position and saved game paths)
 english.CleanupPreviousInstallDir=Delete the entire previous installation directory (removes its backend configuration, library and module data)
@@ -61,9 +65,15 @@ english.CleanupPreviousInstall=Previous installer directory detected:
 english.CleanupNoOldInstall=No valid previous installation directory was detected. Directory deletion is unavailable; other cleanup options still apply to the selected installation directory and user profile data.
 english.CleanupLogPrefix=Optional cleanup:
 english.ServiceUpdateFailed=Failed to update the OmniMixPlayerBackend service path. Check the setup log or run the installer as administrator.
+english.InvalidOldInstallDir=The selected previous installation directory is not recognized as an OmniMixPlayer installation:
+english.DeleteOldInstallFailed=Failed to completely delete the previous installation directory. Close programs using this directory and try again:
 chinesesimplified.CleanupPageTitle=可选清理
 chinesesimplified.CleanupPageDescription=选择需要清理的旧版 OmniMixPlayer 数据
 chinesesimplified.CleanupPageSubCaption=所有选项默认不勾选。请只选择你明确需要删除的数据。
+chinesesimplified.OldInstallDirPageTitle=原安装目录
+chinesesimplified.OldInstallDirPageDescription=选择需要删除的旧版 OmniMixPlayer 安装目录
+chinesesimplified.OldInstallDirPageSubCaption=安装器会自动填入检测到的目录，你也可以浏览选择其他旧版安装目录。仅在勾选删除选项后才会删除该目录。
+chinesesimplified.OldInstallDirLabel=原安装目录：
 chinesesimplified.CleanupAudioCache=清理可重新生成的音频与图片缓存
 chinesesimplified.CleanupGuiSettings=重置桌面 GUI 偏好（主题、音量、快捷键、窗口位置和已保存的游戏路径）
 chinesesimplified.CleanupPreviousInstallDir=完整删除原安装目录（包括其中的后端配置、曲库和模块数据）
@@ -75,6 +85,8 @@ chinesesimplified.CleanupPreviousInstall=检测到上一次安装目录：
 chinesesimplified.CleanupNoOldInstall=未检测到有效的原安装目录，无法使用完整目录删除；其他清理选项仍会作用于当前安装目录和用户配置目录。
 chinesesimplified.CleanupLogPrefix=可选清理：
 chinesesimplified.ServiceUpdateFailed=OmniMixPlayerBackend 服务路径更新失败。请检查安装日志，或以管理员身份重新运行安装程序。
+chinesesimplified.InvalidOldInstallDir=所选目录不是可识别的 OmniMixPlayer 安装目录：
+chinesesimplified.DeleteOldInstallFailed=无法完整删除原安装目录。请关闭正在使用该目录的程序后重试：
 
 [Files]
 ; ═══ 所有可执行文件和 DLL (排除 VC 运行库，它单独处理) ═══
@@ -127,9 +139,12 @@ Filename: "sc.exe"; Parameters: "delete {#MyServiceName}"; Flags: runhidden; Run
 
 var
   CleanupPage: TInputOptionWizardPage;
+  OldInstallDirPage: TInputDirWizardPage;
   OldServiceDir: string;
   PreviousInstallDir: string;
   CleanupConfirmed: Boolean;
+  CleanupFailure: string;
+  ApprovedOldInstallDir: string;
 
 const
   ServiceRegistryPath = 'SYSTEM\CurrentControlSet\Services\{#MyServiceName}';
@@ -246,19 +261,25 @@ begin
   DeleteTreeLogged(Path);
 end;
 
-procedure DeletePreviousInstallDir(const BaseDir: string);
+function DeletePreviousInstallDir(const BaseDir: string): Boolean;
 var
   Normalized: string;
 begin
+  Result := False;
   Normalized := StripTrailingSlash(BaseDir);
-  if not IsKnownInstallDir(Normalized) then
+  if (not IsKnownInstallDir(Normalized)) and
+     (CompareText(Normalized, ApprovedOldInstallDir) <> 0) then
   begin
     if Normalized <> '' then
       Log(CustomMessage('CleanupLogPrefix') + ' refused unrecognized installation directory ' + Normalized);
     Exit;
   end;
 
-  DeleteTreeLogged(Normalized);
+  Result := DelTree(Normalized, True, True, True);
+  if Result then
+    Log(CustomMessage('CleanupLogPrefix') + ' deleted previous installation directory ' + Normalized)
+  else
+    Log(CustomMessage('CleanupLogPrefix') + ' failed to delete previous installation directory ' + Normalized);
 end;
 
 procedure CleanupInstallLocation(const BaseDir: string);
@@ -287,29 +308,38 @@ end;
 procedure RunOptionalCleanup();
 var
   CurrentInstallDir: string;
+  SelectedOldInstallDir: string;
   GuiDataDir: string;
 begin
   CurrentInstallDir := StripTrailingSlash(WizardDirValue());
+  SelectedOldInstallDir := StripTrailingSlash(OldInstallDirPage.Values[0]);
 
   if CleanupPage.Values[2] then
   begin
-    DeletePreviousInstallDir(OldServiceDir);
-    if CompareText(PreviousInstallDir, OldServiceDir) <> 0 then
-      DeletePreviousInstallDir(PreviousInstallDir);
+    if IsKnownInstallDir(SelectedOldInstallDir) then
+      ApprovedOldInstallDir := SelectedOldInstallDir;
+
+    if CompareText(SelectedOldInstallDir, ApprovedOldInstallDir) <> 0 then
+      CleanupFailure :=
+        CustomMessage('InvalidOldInstallDir') + #13#10 + SelectedOldInstallDir
+    else if not DeletePreviousInstallDir(SelectedOldInstallDir) then
+      CleanupFailure :=
+        CustomMessage('DeleteOldInstallFailed') + #13#10 + SelectedOldInstallDir;
   end;
 
-  CleanupInstallLocation(OldServiceDir);
-  if CompareText(PreviousInstallDir, OldServiceDir) <> 0 then
-    CleanupInstallLocation(PreviousInstallDir);
-  if (CompareText(CurrentInstallDir, OldServiceDir) <> 0) and
-     (CompareText(CurrentInstallDir, PreviousInstallDir) <> 0) then
-    CleanupInstallLocation(CurrentInstallDir);
+  if CleanupFailure = '' then
+  begin
+    CleanupInstallLocation(SelectedOldInstallDir);
+    if CompareText(CurrentInstallDir, SelectedOldInstallDir) <> 0 then
+      CleanupInstallLocation(CurrentInstallDir);
+  end;
 
   GuiDataDir := ExpandConstant('{userappdata}\com.omnimixplayer\omnimix_gui');
 
   if CleanupPage.Values[0] then
   begin
     DeleteTreeLogged(AddBackslash(GetEnv('TEMP')) + 'chillpatcher_audio_cache');
+    DeleteTreeLogged(ExpandConstant('{win}\SystemTemp\chillpatcher_audio_cache'));
     DeleteFileLogged(AddBackslash(GuiDataDir) + 'libCachedImageData.json');
   end;
 
@@ -317,7 +347,10 @@ begin
     DeleteFileLogged(AddBackslash(GuiDataDir) + 'shared_preferences.json');
 
   if CleanupPage.Values[3] then
+  begin
     DeleteTreeLogged(ExpandConstant('{localappdata}\go-musicfox'));
+    DeleteTreeLogged(ExpandConstant('{sys}\config\systemprofile\AppData\Local\go-musicfox'));
+  end;
 
   if CleanupPage.Values[4] then
     DeleteTreeLogged(ExpandConstant('{localappdata}\OmniMixPlayer\mod_manager'));
@@ -326,27 +359,38 @@ end;
 procedure InitializeWizard();
 var
   PageSubCaption: string;
-  CanDeletePreviousInstall: Boolean;
+  DetectedInstallDir: string;
 begin
   CleanupConfirmed := False;
+  CleanupFailure := '';
+  ApprovedOldInstallDir := '';
   OldServiceDir := ReadServiceInstallDir();
   PreviousInstallDir := ReadRegisteredInstallDir();
-  CanDeletePreviousInstall :=
-    IsKnownInstallDir(OldServiceDir) or
-    IsKnownInstallDir(PreviousInstallDir);
 
-  if CanDeletePreviousInstall then
+  if IsKnownInstallDir(PreviousInstallDir) then
+    DetectedInstallDir := PreviousInstallDir
+  else if IsKnownInstallDir(OldServiceDir) then
+    DetectedInstallDir := OldServiceDir
+  else
+    DetectedInstallDir := '';
+
+  OldInstallDirPage := CreateInputDirPage(
+    wpSelectDir,
+    CustomMessage('OldInstallDirPageTitle'),
+    CustomMessage('OldInstallDirPageDescription'),
+    CustomMessage('OldInstallDirPageSubCaption'),
+    False,
+    ''
+  );
+  OldInstallDirPage.Add(CustomMessage('OldInstallDirLabel'));
+  OldInstallDirPage.Values[0] := DetectedInstallDir;
+
+  if DetectedInstallDir <> '' then
   begin
     PageSubCaption := CustomMessage('CleanupPageSubCaption');
-    if OldServiceDir <> '' then
-      PageSubCaption :=
-        PageSubCaption + #13#10 + #13#10 +
-        CustomMessage('CleanupOldInstall') + #13#10 + OldServiceDir;
-    if (PreviousInstallDir <> '') and
-       (CompareText(PreviousInstallDir, OldServiceDir) <> 0) then
-      PageSubCaption :=
-        PageSubCaption + #13#10 + #13#10 +
-        CustomMessage('CleanupPreviousInstall') + #13#10 + PreviousInstallDir;
+    PageSubCaption :=
+      PageSubCaption + #13#10 + #13#10 +
+      CustomMessage('CleanupPreviousInstall') + #13#10 + DetectedInstallDir;
   end
   else
     PageSubCaption :=
@@ -354,7 +398,7 @@ begin
       CustomMessage('CleanupNoOldInstall');
 
   CleanupPage := CreateInputOptionPage(
-    wpSelectDir,
+    OldInstallDirPage.ID,
     CustomMessage('CleanupPageTitle'),
     CustomMessage('CleanupPageDescription'),
     PageSubCaption,
@@ -366,7 +410,6 @@ begin
   CleanupPage.Add(CustomMessage('CleanupPreviousInstallDir'));
   CleanupPage.Add(CustomMessage('CleanupLoginData'));
   CleanupPage.Add(CustomMessage('CleanupIntegrationData'));
-  CleanupPage.CheckListBox.ItemEnabled[2] := CanDeletePreviousInstall;
 end;
 
 function NextButtonClick(CurPageID: Integer): Boolean;
@@ -497,6 +540,7 @@ end;
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 begin
   Result := '';
+  CleanupFailure := '';
 
   // 1. 检查并停止 OmniMixPlayerBackend 服务
   if ServiceExists('{#MyServiceName}') then
@@ -525,6 +569,7 @@ begin
 
   // 4. 执行用户在向导中明确选择的清理项
   RunOptionalCleanup();
+  Result := CleanupFailure;
 end;
 
 // ── 安装完成后创建或更新服务 ──

--- a/scripts/installer/OmniMixPlayer.iss
+++ b/scripts/installer/OmniMixPlayer.iss
@@ -40,9 +40,36 @@ MinVersion=10.0.10240
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "chinesesimplified"; MessagesFile: "{#SourcePath}\languages\ChineseSimplified.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[CustomMessages]
+english.CleanupPageTitle=Optional cleanup
+english.CleanupPageDescription=Choose data left by previous OmniMixPlayer installations
+english.CleanupPageSubCaption=All options are disabled by default. Only select data you explicitly want to remove.
+english.CleanupAudioCache=Clear rebuildable audio and image caches
+english.CleanupGuiSettings=Reset desktop GUI preferences (theme, volume, shortcuts, window position and saved game paths)
+english.CleanupBackendData=Reset backend configuration, music library and playback instances
+english.CleanupLoginData=Remove music service sessions stored in default locations (NetEase, QQ Music, Bilibili and Spotify)
+english.CleanupIntegrationData=Remove game integration records, downloaded mod copies and backups (installed game mods remain, but automatic uninstall/restore may no longer work)
+english.CleanupConfirm=The selected cleanup options may remove settings, library data, login sessions or integration backups.%n%nThis operation cannot be undone. Continue?
+english.CleanupOldInstall=Previous backend directory detected:
+english.CleanupNoOldInstall=No previous backend directory was detected. Cleanup will apply to the selected installation directory and user profile data.
+english.CleanupLogPrefix=Optional cleanup:
+chinesesimplified.CleanupPageTitle=可选清理
+chinesesimplified.CleanupPageDescription=选择需要清理的旧版 OmniMixPlayer 数据
+chinesesimplified.CleanupPageSubCaption=所有选项默认不勾选。请只选择你明确需要删除的数据。
+chinesesimplified.CleanupAudioCache=清理可重新生成的音频与图片缓存
+chinesesimplified.CleanupGuiSettings=重置桌面 GUI 偏好（主题、音量、快捷键、窗口位置和已保存的游戏路径）
+chinesesimplified.CleanupBackendData=重置后端配置、曲库和播放实例
+chinesesimplified.CleanupLoginData=删除默认位置中的音乐源登录状态（网易云、QQ 音乐、Bilibili 和 Spotify）
+chinesesimplified.CleanupIntegrationData=删除游戏集成记录、已下载的 Mod 副本和备份（不会卸载游戏中的 Mod，但之后可能无法自动卸载或恢复）
+chinesesimplified.CleanupConfirm=所选清理项可能删除设置、曲库、登录状态或游戏集成备份。%n%n此操作无法撤销，是否继续？
+chinesesimplified.CleanupOldInstall=检测到旧后端目录：
+chinesesimplified.CleanupNoOldInstall=未检测到旧后端目录。清理将作用于当前选择的安装目录和用户配置目录。
+chinesesimplified.CleanupLogPrefix=可选清理：
 
 [Files]
 ; ═══ 所有可执行文件和 DLL (排除 VC 运行库，它单独处理) ═══
@@ -84,14 +111,250 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 
 [UninstallRun]
 ; 卸载前停止并删除服务
-Filename: "sc.exe"; Parameters: "stop {#MyServiceName}"; Flags: runhidden
-Filename: "sc.exe"; Parameters: "delete {#MyServiceName}"; Flags: runhidden
+Filename: "sc.exe"; Parameters: "stop {#MyServiceName}"; Flags: runhidden; RunOnceId: "StopOmniMixPlayerBackend"
+Filename: "sc.exe"; Parameters: "delete {#MyServiceName}"; Flags: runhidden; RunOnceId: "DeleteOmniMixPlayerBackend"
 
 ; ═════════════════════════════════════════════════════════════════════════════
 ; [Code] 部分 — Pascal 脚本
 ; ═════════════════════════════════════════════════════════════════════════════
 
 [Code]
+
+var
+  CleanupPage: TInputOptionWizardPage;
+  OldInstallDir: string;
+  CleanupConfirmed: Boolean;
+
+const
+  ServiceRegistryPath = 'SYSTEM\CurrentControlSet\Services\{#MyServiceName}';
+  UninstallRegistryPath = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}_is1';
+
+// ── 字符串和路径辅助函数 ──
+function StripTrailingSlash(Value: string): string;
+begin
+  Result := Trim(Value);
+  while (Length(Result) > 3) and
+        ((Result[Length(Result)] = '\') or (Result[Length(Result)] = '/')) do
+    Delete(Result, Length(Result), 1);
+end;
+
+function ExtractExecutablePath(ImagePath: string): string;
+var
+  EndPos: Integer;
+  LowerPath: string;
+begin
+  Result := '';
+  ImagePath := Trim(ImagePath);
+  if ImagePath = '' then
+    Exit;
+
+  if ImagePath[1] = '"' then
+  begin
+    Delete(ImagePath, 1, 1);
+    EndPos := Pos('"', ImagePath);
+    if EndPos > 0 then
+      Result := Copy(ImagePath, 1, EndPos - 1)
+    else
+      Result := ImagePath;
+  end
+  else
+  begin
+    LowerPath := Lowercase(ImagePath);
+    EndPos := Pos('.exe', LowerPath);
+    if EndPos > 0 then
+      Result := Copy(ImagePath, 1, EndPos + 3)
+    else
+      Result := ImagePath;
+  end;
+
+  Result := RemoveQuotes(Trim(Result));
+end;
+
+function ReadServiceInstallDir(): string;
+var
+  ImagePath: string;
+  BackendPath: string;
+begin
+  Result := '';
+  ImagePath := '';
+  if IsWin64 then
+    RegQueryStringValue(HKLM64, ServiceRegistryPath, 'ImagePath', ImagePath);
+  if ImagePath = '' then
+    RegQueryStringValue(HKLM, ServiceRegistryPath, 'ImagePath', ImagePath);
+
+  BackendPath := ExtractExecutablePath(ImagePath);
+  if BackendPath <> '' then
+    Result := StripTrailingSlash(ExtractFileDir(BackendPath));
+end;
+
+function ReadRegisteredInstallDir(): string;
+begin
+  Result := '';
+  if IsWin64 then
+    RegQueryStringValue(HKLM64, UninstallRegistryPath, 'InstallLocation', Result);
+  if Result = '' then
+    RegQueryStringValue(HKLM, UninstallRegistryPath, 'InstallLocation', Result);
+  if Result = '' then
+    RegQueryStringValue(HKCU, UninstallRegistryPath, 'InstallLocation', Result);
+  Result := StripTrailingSlash(RemoveQuotes(Result));
+end;
+
+function IsKnownInstallDir(const BaseDir: string): Boolean;
+var
+  Normalized: string;
+begin
+  Normalized := StripTrailingSlash(BaseDir);
+  Result :=
+    (Length(Normalized) > 3) and
+    (
+      FileExists(AddBackslash(Normalized) + '{#MyAppBackendName}') or
+      FileExists(AddBackslash(Normalized) + '{#MyAppExeName}') or
+      DirExists(AddBackslash(Normalized) + 'config') or
+      DirExists(AddBackslash(Normalized) + 'modules')
+    );
+end;
+
+procedure DeleteFileLogged(const FileName: string);
+begin
+  if FileExists(FileName) then
+  begin
+    if DeleteFile(FileName) then
+      Log(CustomMessage('CleanupLogPrefix') + ' deleted file ' + FileName)
+    else
+      Log(CustomMessage('CleanupLogPrefix') + ' failed to delete file ' + FileName);
+  end;
+end;
+
+procedure DeleteTreeLogged(const DirName: string);
+begin
+  if DirExists(DirName) then
+  begin
+    if DelTree(DirName, True, True, True) then
+      Log(CustomMessage('CleanupLogPrefix') + ' deleted directory ' + DirName)
+    else
+      Log(CustomMessage('CleanupLogPrefix') + ' failed to delete directory ' + DirName);
+  end;
+end;
+
+procedure DeleteFileOrTreeLogged(const Path: string);
+begin
+  DeleteFileLogged(Path);
+  DeleteTreeLogged(Path);
+end;
+
+procedure CleanupInstallLocation(const BaseDir: string);
+var
+  ModulesDir: string;
+begin
+  if not IsKnownInstallDir(BaseDir) then
+    Exit;
+
+  ModulesDir := AddBackslash(StripTrailingSlash(BaseDir)) + 'modules\';
+
+  if CleanupPage.Values[0] then
+  begin
+    DeleteTreeLogged(ModulesDir + 'com.chillpatcher.qqmusic\data\audio_cache');
+    DeleteTreeLogged(ModulesDir + 'com.chillpatcher.spotify\data\librespot-cache');
+  end;
+
+  if CleanupPage.Values[2] then
+    DeleteTreeLogged(AddBackslash(StripTrailingSlash(BaseDir)) + 'config');
+
+  if CleanupPage.Values[3] then
+  begin
+    DeleteFileLogged(ModulesDir + 'com.chillpatcher.qqmusic\data\qqmusic_cookie.json');
+    DeleteFileLogged(ModulesDir + 'com.chillpatcher.bilibili\data\bilibili_session.json');
+    DeleteFileLogged(ModulesDir + 'com.chillpatcher.spotify\data\spotify_session.json');
+  end;
+end;
+
+procedure RunOptionalCleanup();
+var
+  CurrentInstallDir: string;
+  GuiDataDir: string;
+begin
+  CurrentInstallDir := StripTrailingSlash(WizardDirValue());
+
+  CleanupInstallLocation(OldInstallDir);
+  if CompareText(OldInstallDir, CurrentInstallDir) <> 0 then
+    CleanupInstallLocation(CurrentInstallDir);
+
+  GuiDataDir := ExpandConstant('{userappdata}\com.omnimixplayer\omnimix_gui');
+
+  if CleanupPage.Values[0] then
+  begin
+    DeleteTreeLogged(AddBackslash(GetEnv('TEMP')) + 'chillpatcher_audio_cache');
+    DeleteFileLogged(AddBackslash(GuiDataDir) + 'libCachedImageData.json');
+  end;
+
+  if CleanupPage.Values[1] then
+    DeleteFileLogged(AddBackslash(GuiDataDir) + 'shared_preferences.json');
+
+  if CleanupPage.Values[3] then
+    DeleteFileOrTreeLogged(ExpandConstant('{localappdata}\go-musicfox\cookie'));
+
+  if CleanupPage.Values[4] then
+    DeleteTreeLogged(ExpandConstant('{localappdata}\OmniMixPlayer\mod_manager'));
+end;
+
+procedure InitializeWizard();
+var
+  PageSubCaption: string;
+begin
+  CleanupConfirmed := False;
+  OldInstallDir := ReadServiceInstallDir();
+  if OldInstallDir = '' then
+    OldInstallDir := ReadRegisteredInstallDir();
+
+  if OldInstallDir <> '' then
+    PageSubCaption :=
+      CustomMessage('CleanupPageSubCaption') + #13#10 + #13#10 +
+      CustomMessage('CleanupOldInstall') + #13#10 + OldInstallDir
+  else
+    PageSubCaption :=
+      CustomMessage('CleanupPageSubCaption') + #13#10 + #13#10 +
+      CustomMessage('CleanupNoOldInstall');
+
+  CleanupPage := CreateInputOptionPage(
+    wpSelectDir,
+    CustomMessage('CleanupPageTitle'),
+    CustomMessage('CleanupPageDescription'),
+    PageSubCaption,
+    False,
+    False
+  );
+  CleanupPage.Add(CustomMessage('CleanupAudioCache'));
+  CleanupPage.Add(CustomMessage('CleanupGuiSettings'));
+  CleanupPage.Add(CustomMessage('CleanupBackendData'));
+  CleanupPage.Add(CustomMessage('CleanupLoginData'));
+  CleanupPage.Add(CustomMessage('CleanupIntegrationData'));
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+var
+  HasDestructiveSelection: Boolean;
+begin
+  Result := True;
+  if CurPageID <> CleanupPage.ID then
+    Exit;
+
+  HasDestructiveSelection :=
+    CleanupPage.Values[1] or
+    CleanupPage.Values[2] or
+    CleanupPage.Values[3] or
+    CleanupPage.Values[4];
+
+  if HasDestructiveSelection and not CleanupConfirmed then
+  begin
+    Result :=
+      MsgBox(
+        CustomMessage('CleanupConfirm'),
+        mbConfirmation,
+        MB_YESNO
+      ) = IDYES;
+    CleanupConfirmed := Result;
+  end;
+end;
 
 // ── 检查 VC++ 2015-2022 x64 运行库是否已安装 ──
 function IsVCRedistInstalled(): Boolean;
@@ -215,6 +478,9 @@ begin
 
   // 再次确认所有进程已停止
   Sleep(1000);
+
+  // 4. 执行用户在向导中明确选择的清理项
+  RunOptionalCleanup();
 end;
 
 // ── 安装完成后重新创建服务 ──

--- a/scripts/installer/OmniMixPlayer.iss
+++ b/scripts/installer/OmniMixPlayer.iss
@@ -52,13 +52,13 @@ english.CleanupPageDescription=Choose data left by previous OmniMixPlayer instal
 english.CleanupPageSubCaption=All options are disabled by default. Only select data you explicitly want to remove.
 english.CleanupAudioCache=Clear rebuildable audio and image caches
 english.CleanupGuiSettings=Reset desktop GUI preferences (theme, volume, shortcuts, window position and saved game paths)
-english.CleanupBackendData=Reset backend configuration, music library and playback instances
+english.CleanupPreviousInstallDir=Delete the entire previous installation directory (removes its backend configuration, library and module data)
 english.CleanupLoginData=Remove music service sessions stored in default locations (NetEase, QQ Music, Bilibili and Spotify)
 english.CleanupIntegrationData=Remove game integration records, downloaded mod copies and backups (installed game mods remain, but automatic uninstall/restore may no longer work)
-english.CleanupConfirm=The selected cleanup options may remove settings, library data, login sessions or integration backups.%n%nThis operation cannot be undone. Continue?
+english.CleanupConfirm=The selected cleanup options may delete the entire previous installation directory, settings, login sessions or integration backups.%n%nThis operation cannot be undone. Continue?
 english.CleanupOldInstall=Previous backend directory detected:
 english.CleanupPreviousInstall=Previous installer directory detected:
-english.CleanupNoOldInstall=No previous backend directory was detected. Cleanup will apply to the selected installation directory and user profile data.
+english.CleanupNoOldInstall=No valid previous installation directory was detected. Directory deletion is unavailable; other cleanup options still apply to the selected installation directory and user profile data.
 english.CleanupLogPrefix=Optional cleanup:
 english.ServiceUpdateFailed=Failed to update the OmniMixPlayerBackend service path. Check the setup log or run the installer as administrator.
 chinesesimplified.CleanupPageTitle=可选清理
@@ -66,13 +66,13 @@ chinesesimplified.CleanupPageDescription=选择需要清理的旧版 OmniMixPlay
 chinesesimplified.CleanupPageSubCaption=所有选项默认不勾选。请只选择你明确需要删除的数据。
 chinesesimplified.CleanupAudioCache=清理可重新生成的音频与图片缓存
 chinesesimplified.CleanupGuiSettings=重置桌面 GUI 偏好（主题、音量、快捷键、窗口位置和已保存的游戏路径）
-chinesesimplified.CleanupBackendData=重置后端配置、曲库和播放实例
+chinesesimplified.CleanupPreviousInstallDir=完整删除原安装目录（包括其中的后端配置、曲库和模块数据）
 chinesesimplified.CleanupLoginData=删除默认位置中的音乐源登录状态（网易云、QQ 音乐、Bilibili 和 Spotify）
 chinesesimplified.CleanupIntegrationData=删除游戏集成记录、已下载的 Mod 副本和备份（不会卸载游戏中的 Mod，但之后可能无法自动卸载或恢复）
-chinesesimplified.CleanupConfirm=所选清理项可能删除设置、曲库、登录状态或游戏集成备份。%n%n此操作无法撤销，是否继续？
+chinesesimplified.CleanupConfirm=所选清理项可能完整删除原安装目录、设置、登录状态或游戏集成备份。%n%n此操作无法撤销，是否继续？
 chinesesimplified.CleanupOldInstall=检测到旧后端目录：
 chinesesimplified.CleanupPreviousInstall=检测到上一次安装目录：
-chinesesimplified.CleanupNoOldInstall=未检测到旧后端目录。清理将作用于当前选择的安装目录和用户配置目录。
+chinesesimplified.CleanupNoOldInstall=未检测到有效的原安装目录，无法使用完整目录删除；其他清理选项仍会作用于当前安装目录和用户配置目录。
 chinesesimplified.CleanupLogPrefix=可选清理：
 chinesesimplified.ServiceUpdateFailed=OmniMixPlayerBackend 服务路径更新失败。请检查安装日志，或以管理员身份重新运行安装程序。
 
@@ -214,9 +214,7 @@ begin
     (Length(Normalized) > 3) and
     (
       FileExists(AddBackslash(Normalized) + '{#MyAppBackendName}') or
-      FileExists(AddBackslash(Normalized) + '{#MyAppExeName}') or
-      DirExists(AddBackslash(Normalized) + 'config') or
-      DirExists(AddBackslash(Normalized) + 'modules')
+      FileExists(AddBackslash(Normalized) + '{#MyAppExeName}')
     );
 end;
 
@@ -248,6 +246,21 @@ begin
   DeleteTreeLogged(Path);
 end;
 
+procedure DeletePreviousInstallDir(const BaseDir: string);
+var
+  Normalized: string;
+begin
+  Normalized := StripTrailingSlash(BaseDir);
+  if not IsKnownInstallDir(Normalized) then
+  begin
+    if Normalized <> '' then
+      Log(CustomMessage('CleanupLogPrefix') + ' refused unrecognized installation directory ' + Normalized);
+    Exit;
+  end;
+
+  DeleteTreeLogged(Normalized);
+end;
+
 procedure CleanupInstallLocation(const BaseDir: string);
 var
   ModulesDir: string;
@@ -263,9 +276,6 @@ begin
     DeleteTreeLogged(ModulesDir + 'com.chillpatcher.spotify\data\librespot-cache');
   end;
 
-  if CleanupPage.Values[2] then
-    DeleteTreeLogged(AddBackslash(StripTrailingSlash(BaseDir)) + 'config');
-
   if CleanupPage.Values[3] then
   begin
     DeleteFileLogged(ModulesDir + 'com.chillpatcher.qqmusic\data\qqmusic_cookie.json');
@@ -280,6 +290,13 @@ var
   GuiDataDir: string;
 begin
   CurrentInstallDir := StripTrailingSlash(WizardDirValue());
+
+  if CleanupPage.Values[2] then
+  begin
+    DeletePreviousInstallDir(OldServiceDir);
+    if CompareText(PreviousInstallDir, OldServiceDir) <> 0 then
+      DeletePreviousInstallDir(PreviousInstallDir);
+  end;
 
   CleanupInstallLocation(OldServiceDir);
   if CompareText(PreviousInstallDir, OldServiceDir) <> 0 then
@@ -309,12 +326,16 @@ end;
 procedure InitializeWizard();
 var
   PageSubCaption: string;
+  CanDeletePreviousInstall: Boolean;
 begin
   CleanupConfirmed := False;
   OldServiceDir := ReadServiceInstallDir();
   PreviousInstallDir := ReadRegisteredInstallDir();
+  CanDeletePreviousInstall :=
+    IsKnownInstallDir(OldServiceDir) or
+    IsKnownInstallDir(PreviousInstallDir);
 
-  if (OldServiceDir <> '') or (PreviousInstallDir <> '') then
+  if CanDeletePreviousInstall then
   begin
     PageSubCaption := CustomMessage('CleanupPageSubCaption');
     if OldServiceDir <> '' then
@@ -342,9 +363,10 @@ begin
   );
   CleanupPage.Add(CustomMessage('CleanupAudioCache'));
   CleanupPage.Add(CustomMessage('CleanupGuiSettings'));
-  CleanupPage.Add(CustomMessage('CleanupBackendData'));
+  CleanupPage.Add(CustomMessage('CleanupPreviousInstallDir'));
   CleanupPage.Add(CustomMessage('CleanupLoginData'));
   CleanupPage.Add(CustomMessage('CleanupIntegrationData'));
+  CleanupPage.CheckListBox.ItemEnabled[2] := CanDeletePreviousInstall;
 end;
 
 function NextButtonClick(CurPageID: Integer): Boolean;

--- a/scripts/installer/languages/ChineseSimplified.LICENSE
+++ b/scripts/installer/languages/ChineseSimplified.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 - 2020 kirakira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/installer/languages/ChineseSimplified.isl
+++ b/scripts/installer/languages/ChineseSimplified.isl
@@ -1,0 +1,419 @@
+; *** Inno Setup version 6.5.0+ Chinese Simplified messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Maintainer: Zhenghan Yang (Kira)
+; Email: 847320916@QQ.com
+; Github: https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+; Encoding: UTF-8
+; Translation based on network resource
+;
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=简体中文
+; If Language Name display incorrect, uncomment next line
+; LanguageName=<7B80><4F53><4E2D><6587>
+; About LanguageID, to reference link:
+; https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c
+LanguageID=$0804
+; LanguageCodePage should always be set if possible, even if this file is Unicode
+; For English it's set to zero anyway because English only uses ASCII characters
+LanguageCodePage=936
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=9
+;DialogFontBaseScaleWidth=7
+;DialogFontBaseScaleHeight=15
+;WelcomeFontName=Segoe UI
+;WelcomeFontSize=14
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=安装
+SetupWindowTitle=安装 - %1
+UninstallAppTitle=卸载
+UninstallAppFullTitle=%1 卸载
+
+; *** Misc. common
+InformationTitle=信息
+ConfirmTitle=确认
+ErrorTitle=错误
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=现在将安装 %1。您想要继续吗？
+LdrCannotCreateTemp=无法创建临时文件。安装程序已中止
+LdrCannotExecTemp=无法执行临时目录中的文件。安装程序已中止
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1。%n%n错误 %2: %3
+SetupFileMissing=安装目录中缺少文件 %1。请修正这个问题或者获取程序的新副本。
+SetupFileCorrupt=安装文件已损坏。请获取程序的新副本。
+SetupFileCorruptOrWrongVer=安装文件已损坏，或是与这个安装程序的版本不兼容。请修正这个问题或获取新的程序副本。
+InvalidParameter=无效的命令行参数：%n%n%1
+SetupAlreadyRunning=安装程序正在运行。
+WindowsVersionNotSupported=此程序不支持当前计算机运行的 Windows 版本。
+WindowsServicePackRequired=此程序需要 %1 服务包 %2 或更高版本。
+NotOnThisPlatform=此程序不能在 %1 上运行。
+OnlyOnThisPlatform=此程序只能在 %1 上运行。
+OnlyOnTheseArchitectures=此程序只能安装到为下列处理器架构设计的 Windows 版本中：%n%n%1
+WinVersionTooLowError=此程序需要 %1 版本 %2 或更高。
+WinVersionTooHighError=此程序不能安装于 %1 版本 %2 或更高。
+AdminPrivilegesRequired=在安装此程序时您必须以管理员身份登录。
+PowerUserPrivilegesRequired=在安装此程序时您必须以管理员身份或有权限的用户组身份登录。
+SetupAppRunningError=安装程序发现 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+UninstallAppRunningError=卸载程序发现 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=选择安装程序模式
+PrivilegesRequiredOverrideInstruction=选择安装模式
+PrivilegesRequiredOverrideText1=%1 可以为所有用户安装（需要管理员权限），或仅为您安装。
+PrivilegesRequiredOverrideText2=%1 可以仅为您安装，或为所有用户安装（需要管理员权限）。
+PrivilegesRequiredOverrideAllUsers=为所有用户安装(&A)
+PrivilegesRequiredOverrideAllUsersRecommended=为所有用户安装(&A)（建议选项）
+PrivilegesRequiredOverrideCurrentUser=仅为我安装(&M)
+PrivilegesRequiredOverrideCurrentUserRecommended=仅为我安装(&M)（建议选项）
+
+; *** Misc. errors
+ErrorCreatingDir=安装程序无法创建目录“%1”
+ErrorTooManyFilesInDir=无法在目录“%1”中创建文件，因为里面包含太多文件
+
+; *** Setup common messages
+ExitSetupTitle=退出安装程序
+ExitSetupMessage=安装程序尚未完成。如果现在退出，将不会安装该程序。%n%n您之后可以再次运行安装程序完成安装。%n%n现在退出安装程序吗？
+AboutSetupMenuItem=关于安装程序(&A)...
+AboutSetupTitle=关于安装程序
+AboutSetupMessage=%1 版本 %2%n%3%n%n%1 主页：%n%4
+AboutSetupNote=
+TranslatorNote=简体中文翻译由 Kira（847320916@qq.com）维护。项目地址：https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+
+; *** Buttons
+ButtonBack=< 上一步(&B)
+ButtonNext=下一步(&N) >
+ButtonInstall=安装(&I)
+ButtonOK=确定
+ButtonCancel=取消
+ButtonYes=是(&Y)
+ButtonYesToAll=全是(&A)
+ButtonNo=否(&N)
+ButtonNoToAll=全否(&O)
+ButtonFinish=完成(&F)
+ButtonBrowse=浏览(&B)...
+ButtonWizardBrowse=浏览(&R)...
+ButtonNewFolder=新建文件夹(&M)
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=选择安装语言
+SelectLanguageLabel=选择安装时使用的语言。
+
+; *** Common wizard text
+ClickNext=点击“下一步”继续，或点击“取消”退出安装程序。
+BeveledLabel=
+BrowseDialogTitle=浏览文件夹
+BrowseDialogLabel=在下面的列表中选择一个文件夹，然后点击“确定”。
+NewFolderName=新建文件夹
+
+; *** "Welcome" wizard page
+WelcomeLabel1=欢迎使用 [name] 安装向导
+WelcomeLabel2=即将在您的计算机上安装 [name/ver]。%n%n建议您在继续安装前关闭所有其他应用程序。
+
+; *** "Password" wizard page
+WizardPassword=密码
+PasswordLabel1=此安装程序需要密码验证。
+PasswordLabel3=请输入密码，然后点击“下一步”继续。密码区分大小写。
+PasswordEditLabel=密码(&P)：
+IncorrectPassword=您输入的密码不正确，请重新输入。
+
+; *** "License Agreement" wizard page
+WizardLicense=许可协议
+LicenseLabel=请在继续安装前阅读以下重要信息。
+LicenseLabel3=请仔细阅读下列许可协议。在继续安装前您必须同意这些协议条款。
+LicenseAccepted=我同意此协议(&A)
+LicenseNotAccepted=我不同意此协议(&D)
+
+; *** "Information" wizard pages
+WizardInfoBefore=信息
+InfoBeforeLabel=请在继续安装前阅读以下重要信息。
+InfoBeforeClickLabel=准备好继续安装后，点击“下一步”。
+WizardInfoAfter=信息
+InfoAfterLabel=请在继续安装前阅读以下重要信息。
+InfoAfterClickLabel=准备好继续安装后，点击“下一步”。
+
+; *** "User Information" wizard page
+WizardUserInfo=用户信息
+UserInfoDesc=请输入您的信息。
+UserInfoName=用户名(&U)：
+UserInfoOrg=组织(&O)：
+UserInfoSerial=序列号(&S)：
+UserInfoNameRequired=请输入用户名。
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=选择目标位置
+SelectDirDesc=您想将 [name] 安装在哪里？
+SelectDirLabel3=安装程序将安装 [name] 到下面的文件夹中。
+SelectDirBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+DiskSpaceGBLabel=至少需要有 [gb] GB 的可用磁盘空间。
+DiskSpaceMBLabel=至少需要有 [mb] MB 的可用磁盘空间。
+CannotInstallToNetworkDrive=安装程序无法安装到一个网络驱动器。
+CannotInstallToUNCPath=安装程序无法安装到一个 UNC 路径。
+InvalidPath=您必须输入一个带驱动器卷标的完整路径，例如：%n%nC:\APP%n%n或UNC路径：%n%n\\server\share
+InvalidDrive=您选定的驱动器或 UNC 共享不存在或不能访问。请选择其他位置。
+DiskSpaceWarningTitle=磁盘空间不足
+DiskSpaceWarning=安装程序至少需要 %1 KB 的可用空间才能安装，但选定驱动器只有 %2 KB 的可用空间。%n%n您一定要继续吗？
+DirNameTooLong=文件夹名称或路径太长。
+InvalidDirName=文件夹名称无效。
+BadDirName32=文件夹名称不能包含下列任何字符：%n%n%1
+DirExistsTitle=文件夹已存在
+DirExists=文件夹：%n%n%1%n%n已经存在。您一定要安装到这个文件夹中吗？
+DirDoesntExistTitle=文件夹不存在
+DirDoesntExist=文件夹：%n%n%1%n%n不存在。您想要创建此文件夹吗？
+
+; *** "Select Components" wizard page
+WizardSelectComponents=选择组件
+SelectComponentsDesc=您想安装哪些程序组件？
+SelectComponentsLabel2=选中您想安装的组件；取消您不想安装的组件。然后点击“下一步”继续。
+FullInstallation=完全安装
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=简洁安装
+CustomInstallation=自定义安装
+NoUninstallWarningTitle=组件已存在
+NoUninstallWarning=安装程序检测到下列组件已安装在您的计算机中：%n%n%1%n%n取消选中这些组件不会卸载它们。%n%n确定要继续吗？
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=当前选择的组件需要至少 [gb] GB 的磁盘空间。
+ComponentsDiskSpaceMBLabel=当前选择的组件需要至少 [mb] MB 的磁盘空间。
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=选择附加任务
+SelectTasksDesc=您想要安装程序执行哪些附加任务？
+SelectTasksLabel2=选择您想要安装程序在安装 [name] 时执行的附加任务，然后点击“下一步”。
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=选择开始菜单文件夹
+SelectStartMenuFolderDesc=安装程序应该在哪里放置程序的快捷方式？
+SelectStartMenuFolderLabel3=安装程序将在下列“开始”菜单文件夹中创建程序的快捷方式。
+SelectStartMenuFolderBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+MustEnterGroupName=您必须输入一个文件夹名。
+GroupNameTooLong=文件夹名或路径太长。
+InvalidGroupName=无效的文件夹名字。
+BadGroupName=文件夹名不能包含下列任何字符：%n%n%1
+NoProgramGroupCheck2=不创建开始菜单文件夹(&D)
+
+; *** "Ready to Install" wizard page
+WizardReady=准备安装
+ReadyLabel1=安装程序准备就绪，现在可以开始安装 [name] 到您的计算机。
+ReadyLabel2a=点击“安装”继续此安装程序。如果您想重新考虑或修改任何设置，点击“上一步”。
+ReadyLabel2b=点击“安装”继续此安装程序。
+ReadyMemoUserInfo=用户信息：
+ReadyMemoDir=目标位置：
+ReadyMemoType=安装类型：
+ReadyMemoComponents=已选择组件：
+ReadyMemoGroup=开始菜单文件夹：
+ReadyMemoTasks=附加任务：
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel2=正在下载文件...
+ButtonStopDownload=停止下载(&S)
+StopDownload=您确定要停止下载吗？
+ErrorDownloadAborted=下载已中止
+ErrorDownloadFailed=下载失败：%1 %2
+ErrorDownloadSizeFailed=获取大小失败：%1 %2
+ErrorProgress=无效的进度：%1 / %2
+ErrorFileSize=文件大小错误：预期 %1，实际 %2
+
+; *** TExtractionWizardPage wizard page and ExtractArchive
+ExtractingLabel=正在提取文件...
+ButtonStopExtraction=停止提取(&S)
+StopExtraction=您确定要停止提取吗？
+ErrorExtractionAborted=提取已中止
+ErrorExtractionFailed=提取失败：%1
+
+; *** Archive extraction failure details
+ArchiveIncorrectPassword=密码不正确
+ArchiveIsCorrupted=压缩包已损坏
+ArchiveUnsupportedFormat=不支持的压缩包格式
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=正在准备安装
+PreparingDesc=安装程序正在准备安装 [name] 到您的计算机。
+PreviousInstallNotCompleted=先前的程序安装或卸载未完成，需要您重启计算机。%n%n在重启计算机后，再次运行安装程序以完成 [name] 的安装。
+CannotContinue=安装程序不能继续。请点击“取消”退出。
+ApplicationsFound=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。
+ApplicationsFound2=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。安装完成后，安装程序将尝试重新启动这些应用程序。
+CloseApplications=自动关闭应用程序(&A)
+DontCloseApplications=不要关闭应用程序(&D)
+ErrorCloseApplications=安装程序无法自动关闭所有应用程序。建议您在继续之前，关闭所有在使用需要由安装程序更新的文件的应用程序。
+PrepareToInstallNeedsRestart=安装程序必须重启您的计算机。计算机重启后，请再次运行安装程序以完成 [name] 的安装。%n%n要立即重启吗？
+
+; *** "Installing" wizard page
+WizardInstalling=正在安装
+InstallingLabel=安装程序正在安装 [name] 到您的计算机，请稍候。
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=[name] 安装完成
+FinishedLabelNoIcons=安装程序已在您的计算机中安装了 [name]。
+FinishedLabel=安装程序已在您的计算机中安装了 [name]。您可以通过已安装的快捷方式运行此应用程序。
+ClickFinish=点击“完成”退出安装程序。
+FinishedRestartLabel=为完成 [name] 的安装，安装程序必须重新启动您的计算机。要立即重启吗？
+FinishedRestartMessage=为完成 [name] 的安装，安装程序必须重新启动您的计算机。%n%n要立即重启吗？
+ShowReadmeCheck=是，我想查阅自述文件
+YesRadio=是，立即重启计算机(&Y)
+NoRadio=否，稍后重启计算机(&N)
+; used for example as 'Run MyProg.exe'
+RunEntryExec=运行 %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=查阅 %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=安装程序需要下一张磁盘
+SelectDiskLabel2=请插入磁盘 %1 并点击“确定”。%n%n如果这个磁盘中的文件可以在下列文件夹之外的文件夹中找到，请输入正确的路径或点击“浏览”。
+PathLabel=路径(&P)：
+FileNotInDir2=“%2”中找不到文件“%1”。请插入正确的磁盘或选择其他文件夹。
+SelectDirectoryLabel=请指定下一张磁盘的位置。
+
+; *** Installation phase messages
+SetupAborted=安装程序未完成安装。%n%n请修正这个问题并重新运行安装程序。
+AbortRetryIgnoreSelectAction=选择操作
+AbortRetryIgnoreRetry=重试(&T)
+AbortRetryIgnoreIgnore=忽略错误并继续(&I)
+AbortRetryIgnoreCancel=关闭安装程序
+RetryCancelSelectAction=选择操作
+RetryCancelRetry=重试(&T)
+RetryCancelCancel=取消
+
+; *** Installation status messages
+StatusClosingApplications=正在关闭应用程序...
+StatusCreateDirs=正在创建目录...
+StatusExtractFiles=正在提取文件...
+StatusDownloadFiles=正在下载文件...
+StatusCreateIcons=正在创建快捷方式...
+StatusCreateIniEntries=正在创建 INI 条目...
+StatusCreateRegistryEntries=正在创建注册表条目...
+StatusRegisterFiles=正在注册文件...
+StatusSavingUninstall=正在保存卸载信息...
+StatusRunProgram=正在完成安装...
+StatusRestartingApplications=正在重启应用程序...
+StatusRollback=正在撤销更改...
+
+; *** Misc. errors
+ErrorInternal2=内部错误：%1
+ErrorFunctionFailedNoCode=%1 失败
+ErrorFunctionFailed=%1 失败；错误代码 %2
+ErrorFunctionFailedWithMessage=%1 失败；错误代码 %2.%n%3
+ErrorExecutingProgram=无法执行文件：%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=打开注册表项时出错：%n%1\%2
+ErrorRegCreateKey=创建注册表项时出错：%n%1\%2
+ErrorRegWriteKey=写入注册表项时出错：%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=在文件“%1”中创建 INI 条目时出错。
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=跳过此文件(&S)（不推荐）
+FileAbortRetryIgnoreIgnoreNotRecommended=忽略错误并继续(&I)（不推荐）
+SourceIsCorrupted=源文件已损坏
+SourceDoesntExist=源文件“%1”不存在
+SourceVerificationFailed=源文件验证失败：%1
+VerificationSignatureDoesntExist=签名文件“%1”不存在
+VerificationSignatureInvalid=签名文件“%1”无效
+VerificationKeyNotFound=签名文件“%1”使用了未知的密钥
+VerificationFileNameIncorrect=文件名不正确
+VerificationFileTagIncorrect=文件标签不正确
+VerificationFileSizeIncorrect=文件大小不正确
+VerificationFileHashIncorrect=文件校验和不匹配
+ExistingFileReadOnly2=无法替换现有文件，它是只读的。
+ExistingFileReadOnlyRetry=移除只读属性并重试(&R)
+ExistingFileReadOnlyKeepExisting=保留现有文件(&K)
+ErrorReadingExistingDest=尝试读取现有文件时出错：
+FileExistsSelectAction=选择操作
+FileExists2=文件已经存在。
+FileExistsOverwriteExisting=覆盖已存在的文件(&O)
+FileExistsKeepExisting=保留现有的文件(&K)
+FileExistsOverwriteOrKeepAll=为所有冲突文件执行此操作(&D)
+ExistingFileNewerSelectAction=选择操作
+ExistingFileNewer2=现有的文件比安装程序将要安装的文件还要新。
+ExistingFileNewerOverwriteExisting=覆盖已存在的文件(&O)
+ExistingFileNewerKeepExisting=保留现有的文件(&K)（推荐）
+ExistingFileNewerOverwriteOrKeepAll=为所有冲突文件执行此操作(&D)
+ErrorChangingAttr=尝试更改下列现有文件的属性时出错：
+ErrorCreatingTemp=尝试在目标目录创建文件时出错：
+ErrorReadingSource=尝试读取下列源文件时出错：
+ErrorCopying=尝试复制下列文件时出错：
+ErrorDownloading=尝试下载文件时出错：
+ErrorExtracting=尝试提取压缩包时出错：
+ErrorReplacingExistingFile=尝试替换现有文件时出错：
+ErrorRestartReplace=重启并替换失败：
+ErrorRenamingTemp=尝试重命名下列目标目录中的一个文件时出错：
+ErrorRegisterServer=无法注册 DLL/OCX：%1
+ErrorRegSvr32Failed=RegSvr32 失败；退出代码 %1
+ErrorRegisterTypeLib=无法注册类库：%1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32 位
+UninstallDisplayNameMark64Bit=64 位
+UninstallDisplayNameMarkAllUsers=所有用户
+UninstallDisplayNameMarkCurrentUser=当前用户
+
+; *** Post-installation errors
+ErrorOpeningReadme=尝试打开自述文件时出错。
+ErrorRestartingComputer=安装程序无法重启计算机，请手动重启。
+
+; *** Uninstaller messages
+UninstallNotFound=文件“%1”不存在。无法卸载。
+UninstallOpenError=文件“%1”不能被打开。无法卸载。
+UninstallUnsupportedVer=此版本的卸载程序无法识别卸载日志文件“%1”的格式。无法卸载
+UninstallUnknownEntry=卸载日志中遇到一个未知条目（%1）
+ConfirmUninstall=您确认要完全移除 %1 及其所有组件吗？
+UninstallOnlyOnWin64=仅允许在 64 位 Windows 中卸载此程序。
+OnlyAdminCanUninstall=仅使用管理员权限的用户能完成此卸载。
+UninstallStatusLabel=正在从您的计算机中移除 %1，请稍候。
+UninstalledAll=已顺利从您的计算机中移除 %1。
+UninstalledMost=%1 卸载完成。%n%n有部分内容未能被删除，但您可以手动删除它们。
+UninstalledAndNeedsRestart=为完成 %1 的卸载，需要重启您的计算机。%n%n要立即重启吗？
+UninstallDataCorrupted=文件“%1”已损坏。无法卸载
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=删除共享的文件吗？
+ConfirmDeleteSharedFile2=系统表示下列共享的文件已不有其他程序使用。您希望卸载程序删除这些共享的文件吗？%n%n如果删除这些文件，但仍有程序在使用这些文件，则这些程序可能出现异常。如果您不能确定，请选择“否”，在系统中保留这些文件以免引发问题。
+SharedFileNameLabel=文件名：
+SharedFileLocationLabel=位置：
+WizardUninstalling=卸载状态
+StatusUninstalling=正在卸载 %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=正在安装 %1。
+ShutdownBlockReasonUninstallingApp=正在卸载 %1。
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 版本 %2
+AdditionalIcons=附加快捷方式：
+CreateDesktopIcon=创建桌面快捷方式(&D)
+CreateQuickLaunchIcon=创建快速启动栏快捷方式(&Q)
+ProgramOnTheWeb=%1 网站
+UninstallProgram=卸载 %1
+LaunchProgram=运行 %1
+AssocFileExtension=将 %2 文件扩展名与 %1 建立关联(&A)
+AssocingFileExtension=正在将 %2 文件扩展名与 %1 建立关联...
+AutoStartProgramGroupDescription=启动：
+AutoStartProgram=自动启动 %1
+AddonHostProgramNotFound=您选择的文件夹中无法找到 %1。%n%n您要继续吗？

--- a/scripts/installer/languages/ChineseSimplified.isl
+++ b/scripts/installer/languages/ChineseSimplified.isl
@@ -390,7 +390,7 @@ UninstallDataCorrupted=文件“%1”已损坏。无法卸载
 
 ; *** Uninstallation phase messages
 ConfirmDeleteSharedFileTitle=删除共享的文件吗？
-ConfirmDeleteSharedFile2=系统表示下列共享的文件已不有其他程序使用。您希望卸载程序删除这些共享的文件吗？%n%n如果删除这些文件，但仍有程序在使用这些文件，则这些程序可能出现异常。如果您不能确定，请选择“否”，在系统中保留这些文件以免引发问题。
+ConfirmDeleteSharedFile2=系统表示下列共享的文件已不再被其他程序使用。您希望卸载程序删除这些共享的文件吗？%n%n如果删除这些文件，但仍有程序在使用这些文件，则这些程序可能出现异常。如果您不能确定，请选择“否”，在系统中保留这些文件以免引发问题。
 SharedFileNameLabel=文件名：
 SharedFileLocationLabel=位置：
 WizardUninstalling=卸载状态

--- a/scripts/installer/languages/LICENSE-ChineseSimplified-Translation.txt
+++ b/scripts/installer/languages/LICENSE-ChineseSimplified-Translation.txt
@@ -1,3 +1,11 @@
+Third-party license notice
+
+This license applies only to ChineseSimplified.isl, sourced from:
+https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+
+ChillPatcher remains licensed under the GNU General Public License v3.0.
+See the repository root LICENSE file for the main project's license.
+
 MIT License
 
 Copyright (c) 2019 - 2020 kirakira


### PR DESCRIPTION
## 背景

OmniMixPlayer 后端以 `LocalSystem` Windows 服务运行。更换安装目录或重新安装时，旧目录中的曲库数据库、系统账户下的音乐源登录状态和旧服务路径可能继续生效，导致删除旧版本后仍自动登录并重新导入曲库。

## 修改内容

- 增加英文和简体中文安装界面，简体中文翻译及 MIT 许可证随仓库提供。
- 安装目录页面始终显示，允许用户自定义新版安装位置。
- 增加“原安装目录”页面：自动检测服务或卸载注册表记录，用户也可以手动浏览指定旧版本目录。
- 增加默认不勾选的可选清理页面：
  - 清理可重新生成的音频与图片缓存
  - 重置桌面 GUI 偏好
  - 完整删除用户指定的原安装目录
  - 删除音乐源登录状态
  - 删除游戏集成管理记录、下载副本和备份
- 登录状态清理同时覆盖当前用户和 `LocalSystem` 服务账户使用的网易云数据，并覆盖 QQ 音乐、Bilibili、Spotify 的已知默认会话文件。
- 缓存清理同时覆盖当前用户临时目录和 `C:\Windows\SystemTemp\chillpatcher_audio_cache`。
- 安装前停止服务和相关进程，安装后创建或更新服务，使其指向新版安装目录。

## 安全与失败处理

- 完整目录删除仅允许作用于包含 OmniMixPlayer 后端或 GUI 可执行文件的目录，拒绝未知目录和磁盘根目录。
- 用户更改原安装目录或清理范围后，必须重新确认破坏性操作。
- 原安装目录或登录状态清理失败时中止安装并显示失败路径，避免静默显示清理成功。
- 卸载器仅在后端服务确实指向当前卸载目录时停止并删除该服务，避免影响其他安装。
- 提权流程中的 `sc.exe`、`tasklist.exe`、`taskkill.exe` 和命令解释器均使用 Windows 系统绝对路径，避免可执行文件搜索路径劫持。
- 游戏集成清理不会删除游戏目录中已经安装的 Mod，但删除管理记录和备份后可能无法自动卸载或恢复。
- 不删除本地音乐文件夹，也不擅自删除未知的自定义数据目录。

## 已确认的数据位置

- 后端曲库：`<安装目录>\config\omnimix_library.db`
- 播放实例：`<安装目录>\config\omnimix_instances.db`
- 本地曲库索引：`<安装目录>\modules\com.chillpatcher.localfolder\data\Library\.localfolder.db`
- GUI 偏好：`%APPDATA%\com.omnimixplayer\omnimix_gui\shared_preferences.json`
- 系统服务音频缓存：`C:\Windows\SystemTemp\chillpatcher_audio_cache`
- 网易云登录状态：当前用户或 `LocalSystem` 账户的 `AppData\Local\go-musicfox`

## 验证

- 使用 Inno Setup 6.7.3 和上游 Release 3.0.4 完整 `playerbuild` 编译成功，0 个警告。
- 已验证自定义安装目录、原安装目录选择、完整旧目录删除及登录/曲库清理流程。
- 最新安全与失败处理修复已通过完整安装器编译，等待最终人工回归测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Chinese (Simplified) language support to the installer interface
  * Introduced optional cleanup wizard during installation, allowing users to remove cached files, cookies, and previous installation directories
  * Improved Windows service management during installation and uninstallation

* **Chores**
  * Added Chinese (Simplified) translation license documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->