### PR TITLE
fix(qqmusic): 尝试修复 QQ 音乐不正常跳歌

### DIFF
--- a/NativePlugins/qqmusic_bridge/api/user.go
+++ b/NativePlugins/qqmusic_bridge/api/user.go
@@ -24,10 +24,10 @@ func (c *Client) FetchUserInfo() (*models.UserInfo, error) {
 
 	var result struct {
 		Creator struct {
-			Uin      int64  `json:"uin"`
-			Nick     string `json:"nick"`
-			HeadPic  string `json:"headpic"`
-			EncUin   string `json:"encrypt_uin"`
+			Uin     int64  `json:"uin"`
+			Nick    string `json:"nick"`
+			HeadPic string `json:"headpic"`
+			EncUin  string `json:"encrypt_uin"`
 		} `json:"creator"`
 	}
 
@@ -347,24 +347,24 @@ func (c *Client) GetUserCreatedPlaylists() ([]models.PlaylistInfo, error) {
 	}
 
 	params := map[string]interface{}{
-		"uin":          uin,
-		"size":         200,
-		"offset":       0,
-		"sort":         5, // by update time
+		"uin":    uin,
+		"size":   200,
+		"offset": 0,
+		"sort":   5, // by update time
 	}
 
 	data, err := c.RequestCGI("music.srfDissInfo.aiDissInfo", "get_uin_diss", params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get playlists: %w", err)
+		return c.getUserCreatedPlaylistsFCG(uin)
 	}
 
 	var result struct {
 		DissList []struct {
-			TID      int64  `json:"tid"`
-			DirName  string `json:"diss_name"`
-			SongCnt  int    `json:"song_cnt"`
-			DirPic   string `json:"diss_cover"`
-			Creator  struct {
+			TID     int64  `json:"tid"`
+			DirName string `json:"diss_name"`
+			SongCnt int    `json:"song_cnt"`
+			DirPic  string `json:"diss_cover"`
+			Creator struct {
 				Name string `json:"name"`
 			} `json:"creator"`
 		} `json:"disslist"`
@@ -403,16 +403,16 @@ func (c *Client) GetUserCollectedPlaylists() ([]models.PlaylistInfo, error) {
 
 	data, err := c.RequestCGI("music.srfDissInfo.aiDissInfo", "get_collect_diss", params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get collected playlists: %w", err)
+		return c.getUserCollectedPlaylistsFCG(uin)
 	}
 
 	var result struct {
 		DissList []struct {
-			TID      int64  `json:"tid"`
-			DirName  string `json:"diss_name"`
-			SongCnt  int    `json:"song_cnt"`
-			DirPic   string `json:"diss_cover"`
-			Creator  struct {
+			TID     int64  `json:"tid"`
+			DirName string `json:"diss_name"`
+			SongCnt int    `json:"song_cnt"`
+			DirPic  string `json:"diss_cover"`
+			Creator struct {
 				Name string `json:"name"`
 			} `json:"creator"`
 		} `json:"disslist"`
@@ -433,5 +433,107 @@ func (c *Client) GetUserCollectedPlaylists() ([]models.PlaylistInfo, error) {
 		})
 	}
 
+	return playlists, nil
+}
+
+// getUserCreatedPlaylistsFCG falls back to the profile endpoint when the
+// newer musicu CGI rejects the request with code 40000.
+func (c *Client) getUserCreatedPlaylistsFCG(uin int64) ([]models.PlaylistInfo, error) {
+	c.mu.RLock()
+	cookies := c.cookies
+	gtk := c.gtk
+	c.mu.RUnlock()
+
+	fcgURL := fmt.Sprintf("https://c.y.qq.com/rsc/fcgi-bin/fcg_user_created_diss?hostuin=%d&sin=0&size=200&format=json&g_tk=%d&loginUin=%d&platform=yqq.json&needNewCode=0", uin, gtk, uin)
+	resp, err := c.httpClient.R().
+		SetHeader("Cookie", cookies).
+		SetHeader("Referer", "https://y.qq.com/n/ryqq/profile").
+		SetHeader("Origin", "https://y.qq.com").
+		Get(fcgURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get created playlists from FCG: %w", err)
+	}
+
+	var result struct {
+		Code int `json:"code"`
+		Data struct {
+			DissList []struct {
+				TID      int64  `json:"tid"`
+				DissName string `json:"diss_name"`
+				SongCnt  int    `json:"song_cnt"`
+				CoverURL string `json:"diss_cover"`
+			} `json:"disslist"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse created playlists from FCG: %w", err)
+	}
+	if result.Code != 0 {
+		return nil, fmt.Errorf("created playlists FCG error code: %d", result.Code)
+	}
+
+	playlists := make([]models.PlaylistInfo, 0, len(result.Data.DissList))
+	for _, diss := range result.Data.DissList {
+		if diss.TID <= 0 {
+			continue
+		}
+		playlists = append(playlists, models.PlaylistInfo{
+			DissID:    diss.TID,
+			DissName:  diss.DissName,
+			SongCount: diss.SongCnt,
+			CoverUrl:  diss.CoverURL,
+		})
+	}
+	return playlists, nil
+}
+
+func (c *Client) getUserCollectedPlaylistsFCG(uin int64) ([]models.PlaylistInfo, error) {
+	c.mu.RLock()
+	cookies := c.cookies
+	gtk := c.gtk
+	c.mu.RUnlock()
+
+	fcgURL := fmt.Sprintf("https://c.y.qq.com/fav/fcgi-bin/fcg_get_profile_order_asset.fcg?ct=20&cid=205360956&userid=%d&reqtype=3&sin=0&ein=200&format=json&g_tk=%d&loginUin=%d&platform=yqq.json&needNewCode=0", uin, gtk, uin)
+	resp, err := c.httpClient.R().
+		SetHeader("Cookie", cookies).
+		SetHeader("Referer", "https://y.qq.com/n/ryqq/profile").
+		SetHeader("Origin", "https://y.qq.com").
+		Get(fcgURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get collected playlists from FCG: %w", err)
+	}
+
+	var result struct {
+		Code int `json:"code"`
+		Data struct {
+			CDList []struct {
+				DissID   int64  `json:"dissid"`
+				DissName string `json:"dissname"`
+				SongNum  int    `json:"songnum"`
+				Logo     string `json:"logo"`
+				Nickname string `json:"nickname"`
+			} `json:"cdlist"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse collected playlists from FCG: %w", err)
+	}
+	if result.Code != 0 {
+		return nil, fmt.Errorf("collected playlists FCG error code: %d", result.Code)
+	}
+
+	playlists := make([]models.PlaylistInfo, 0, len(result.Data.CDList))
+	for _, diss := range result.Data.CDList {
+		if diss.DissID <= 0 {
+			continue
+		}
+		playlists = append(playlists, models.PlaylistInfo{
+			DissID:    diss.DissID,
+			DissName:  diss.DissName,
+			SongCount: diss.SongNum,
+			CoverUrl:  diss.Logo,
+			Creator:   diss.Nickname,
+		})
+	}
 	return playlists, nil
 }

--- a/OmniMixPlayer/OmniMixPlayer.Backend/Audio/PlaybackController.cs
+++ b/OmniMixPlayer/OmniMixPlayer.Backend/Audio/PlaybackController.cs
@@ -484,32 +484,9 @@ namespace OmniMixPlayer.Backend.Audio
 
         private static string FormatToString(AudioFormat format, string url, string cachePath)
         {
-            return format switch
-            {
-                AudioFormat.Flac => "flac",
-                AudioFormat.Wav => "wav",
-                AudioFormat.Aac => "aac",
-                AudioFormat.Ogg => "ogg",
-                AudioFormat.Mp3 => "mp3",
-                _ => InferFormatFromPath(cachePath) ?? InferFormatFromPath(url) ?? "mp3"
-            };
+            return AudioFormatExtensions.ToFormatString(format, url, cachePath);
         }
 
-        private static string InferFormatFromPath(string path)
-        {
-            if (string.IsNullOrWhiteSpace(path)) return null;
-            var ext = System.IO.Path.GetExtension(path).TrimStart('.').ToLowerInvariant();
-            return ext switch
-            {
-                "flac" => "flac",
-                "wav" => "wav",
-                "aac" => "aac",
-                "m4a" => "aac",
-                "ogg" => "ogg",
-                "mp3" => "mp3",
-                _ => null
-            };
-        }
 
         private void SetPlayState(int state)
         {

--- a/OmniMixPlayer/OmniMixPlayer.Backend/ModuleSystem/Services/Streaming/CorePcmStreamReader.cs
+++ b/OmniMixPlayer/OmniMixPlayer.Backend/ModuleSystem/Services/Streaming/CorePcmStreamReader.cs
@@ -126,7 +126,10 @@ namespace OmniMixPlayer.Backend.ModuleSystem.Services.Streaming
             _cache.OnComplete += OnCacheComplete;
             _cache.StartDownload();
 
-            StartInitialDecoderOpen();
+            if (AudioFormatExtensions.SupportsProgressiveDecoding(_format))
+            {
+                StartInitialDecoderOpen();
+            }
         }
 
         // ===== Bottle + Tap: open once there is enough data, without blocking creation =====
@@ -197,13 +200,33 @@ namespace OmniMixPlayer.Backend.ModuleSystem.Services.Streaming
             }
         }
 
-        // ===== OnCacheComplete: just a flag, no switch =====
+        // ===== OnCacheComplete: open decoder or transition it to non-growing =====
 
         private void OnCacheComplete()
         {
-            // Nothing to do. The decoder is already reading from the file.
-            // When ReadFrames returns 0 and cache is complete → real EOF.
-            _logger?.LogInformation("Cache complete — decoder will naturally reach EOF");
+            _logger?.LogInformation("Cache complete — transitioning decoder to non-growing");
+
+            if (_disposed || _cache == null)
+                return;
+
+            try
+            {
+                lock (_lock)
+                {
+                    if (_decoder != null && _pendingSeek < 0)
+                    {
+                        _pendingSeek = (long)_currentFrame;
+                    }
+                }
+
+                OpenDecoder(_cache.CachePath, false);
+                _isReady = true;
+                _logger?.LogInformation("Decoder opened/reopened after cache completion");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Failed to open/reopen decoder after cache completion: {Msg}", ex.Message);
+            }
         }
 
         // ===== ReadFrames: single data path =====
@@ -213,11 +236,18 @@ namespace OmniMixPlayer.Backend.ModuleSystem.Services.Streaming
             if (_disposed) return 0;
 
             // Lazy init: if the background open did not finish yet, try now.
-            if (_decoder == null && _cache != null &&
-                (_cache.Downloaded >= 65536 || _cache.IsComplete))
+            if (_decoder == null && _cache != null)
             {
-                try { OpenDecoder(_cache.CachePath, true); _isReady = true; }
-                catch { /* will retry next call */ }
+                if (_cache.IsComplete)
+                {
+                    try { OpenDecoder(_cache.CachePath, false); _isReady = true; }
+                    catch { /* will retry next call */ }
+                }
+                else if (AudioFormatExtensions.SupportsProgressiveDecoding(_format) && _cache.Downloaded >= 65536)
+                {
+                    try { OpenDecoder(_cache.CachePath, true); _isReady = true; }
+                    catch { /* will retry next call */ }
+                }
             }
 
             if (_decoder == null)

--- a/OmniMixPlayer/OmniMixPlayer.Backend/ModuleSystem/Services/Streaming/CorePcmStreamReader.cs
+++ b/OmniMixPlayer/OmniMixPlayer.Backend/ModuleSystem/Services/Streaming/CorePcmStreamReader.cs
@@ -226,6 +226,11 @@ namespace OmniMixPlayer.Backend.ModuleSystem.Services.Streaming
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "Failed to open/reopen decoder after cache completion: {Msg}", ex.Message);
+                lock (_lock)
+                {
+                    _isReady = true;
+                    _isEndOfStream = true;
+                }
             }
         }
 

--- a/OmniMixPlayer/OmniMixPlayer.SDK/Interfaces/IStreamingProvider.cs
+++ b/OmniMixPlayer/OmniMixPlayer.SDK/Interfaces/IStreamingProvider.cs
@@ -332,6 +332,97 @@ namespace OmniMixPlayer.SDK.Interfaces
                 _ => false
             };
         }
+
+        public static string GetFileExtension(this AudioFormat format)
+        {
+            return format switch
+            {
+                AudioFormat.Flac => "flac",
+                AudioFormat.Wav => "wav",
+                AudioFormat.Ogg => "ogg",
+                AudioFormat.Aac => "m4a",
+                AudioFormat.Mp3 => "mp3",
+                _ => "audio"
+            };
+        }
+
+        public static string ToFormatString(this AudioFormat format, string url = null, string cachePath = null)
+        {
+            if (format != AudioFormat.Unknown)
+            {
+                return format switch
+                {
+                    AudioFormat.Flac => "flac",
+                    AudioFormat.Wav => "wav",
+                    AudioFormat.Aac => "aac",
+                    AudioFormat.Ogg => "ogg",
+                    AudioFormat.Mp3 => "mp3",
+                    _ => "mp3"
+                };
+            }
+
+            return InferFormatFromPath(cachePath) ?? InferFormatFromPath(url) ?? "mp3";
+        }
+
+        public static string InferFormatFromPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return null;
+            try
+            {
+                string cleanPath = path;
+                if (path.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                    path.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (Uri.TryCreate(path, UriKind.Absolute, out var uri))
+                    {
+                        cleanPath = uri.AbsolutePath;
+                    }
+                    else
+                    {
+                        cleanPath = path.Split('?', '#')[0];
+                    }
+                }
+                else
+                {
+                    cleanPath = path.Split('?', '#')[0];
+                }
+
+                var ext = System.IO.Path.GetExtension(cleanPath)?.TrimStart('.').ToLowerInvariant();
+                return ext switch
+                {
+                    "flac" => "flac",
+                    "wav" => "wav",
+                    "aac" => "aac",
+                    "m4a" => "aac",
+                    "ogg" => "ogg",
+                    "mp3" => "mp3",
+                    _ => null
+                };
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static string NormalizeAudioFormat(string bridgeFormat, string url)
+        {
+            var format = bridgeFormat?.Trim().TrimStart('.').ToLowerInvariant();
+            if (!string.IsNullOrWhiteSpace(format))
+                return format;
+
+            var inferred = InferFormatFromPath(url);
+            return inferred ?? "mp3";
+        }
+
+        public static bool SupportsProgressiveDecoding(string format)
+        {
+            if (string.IsNullOrWhiteSpace(format))
+                return false;
+
+            var fmt = format.Trim().TrimStart('.').ToLowerInvariant();
+            return fmt != "aac" && fmt != "m4a" && fmt != "mp4" && fmt != "m4s";
+        }
     }
 
     #endregion

--- a/OmniMixPlayer/modules/Netease/NeteaseModule.cs
+++ b/OmniMixPlayer/modules/Netease/NeteaseModule.cs
@@ -318,6 +318,8 @@ namespace OmniMixPlayer.Module.Netease
 
                 // 确定格式
                 var audioFormat = AudioFormatExtensions.FromExtension(songUrl.Type);
+                if (audioFormat == AudioFormat.Unknown)
+                    audioFormat = AudioFormat.Mp3;
                 var format = audioFormat.GetFileExtension();
 
                 _context.Logger.LogInformation($"[{DisplayName}] 获取到歌曲 URL: {songInfo.Name} [format={format}, size={songUrl.Size}, isTrial={songUrl.IsTrial}]");

--- a/OmniMixPlayer/modules/Netease/NeteaseModule.cs
+++ b/OmniMixPlayer/modules/Netease/NeteaseModule.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 
+using OmniMixPlayer.SDK;
 using OmniMixPlayer.SDK.Attributes;
 using OmniMixPlayer.SDK.Events;
 using OmniMixPlayer.SDK.Interfaces;
@@ -316,10 +317,8 @@ namespace OmniMixPlayer.Module.Netease
                 }
 
                 // 确定格式
-                var format = !string.IsNullOrEmpty(songUrl.Type) ? songUrl.Type.ToLowerInvariant() : "mp3";
-                var audioFormat = string.Equals(format, "flac", StringComparison.OrdinalIgnoreCase)
-                    ? AudioFormat.Flac
-                    : AudioFormat.Mp3;
+                var audioFormat = AudioFormatExtensions.FromExtension(songUrl.Type);
+                var format = audioFormat.GetFileExtension();
 
                 _context.Logger.LogInformation($"[{DisplayName}] 获取到歌曲 URL: {songInfo.Name} [format={format}, size={songUrl.Size}, isTrial={songUrl.IsTrial}]");
 

--- a/OmniMixPlayer/modules/QQMusic/QQMusicCoverLoader.cs
+++ b/OmniMixPlayer/modules/QQMusic/QQMusicCoverLoader.cs
@@ -86,7 +86,7 @@ namespace OmniMixPlayer.Module.QQMusic
                 return (_defaultQQMusicCoverBytes, "image/png");
             }
 
-            var result = await DownloadCoverAsync(songInfo.CoverUrl);
+            var result = await DownloadSongCoverAsync(songInfo);
             if (result.data != null)
             {
                 _coverCache[uuid] = result;
@@ -111,7 +111,7 @@ namespace OmniMixPlayer.Module.QQMusic
                     !string.IsNullOrWhiteSpace(s.CoverUrl));
                 if (songInfo != null)
                 {
-                    var result = await DownloadCoverAsync(songInfo.CoverUrl);
+                    var result = await DownloadSongCoverAsync(songInfo);
                     if (result.data != null)
                     {
                         _coverCache[albumId] = result;
@@ -132,19 +132,40 @@ namespace OmniMixPlayer.Module.QQMusic
 
             if (!_songInfoMap.TryGetValue(uuid, out var songInfo))
             {
-                return (null, null);
+                return (_defaultQQMusicCoverBytes, "image/png");
             }
 
             if (string.IsNullOrEmpty(songInfo.CoverUrl))
             {
-                return (null, null);
+                return (_defaultQQMusicCoverBytes, "image/png");
             }
 
-            var result = await DownloadCoverAsync(songInfo.CoverUrl);
+            var result = await DownloadSongCoverAsync(songInfo);
             if (result.data != null && result.data.Length > 0)
             {
                 _coverCache[uuid] = result;
                 return result;
+            }
+
+            return (_defaultQQMusicCoverBytes, "image/png");
+        }
+
+        private async Task<(byte[] data, string mimeType)> DownloadSongCoverAsync(QQMusicBridge.SongInfo songInfo)
+        {
+            var urls = new List<string>();
+            if (!string.IsNullOrWhiteSpace(songInfo?.CoverUrl))
+                urls.Add(QQMusicSongRegistry.NormalizeCoverUrl(songInfo.CoverUrl));
+            if (!string.IsNullOrWhiteSpace(songInfo?.AlbumMid))
+            {
+                urls.Add($"https://y.gtimg.cn/music/photo_new/T002R500x500M000{songInfo.AlbumMid}.jpg");
+                urls.Add($"https://y.gtimg.cn/music/photo_new/T002R300x300M000{songInfo.AlbumMid}.jpg");
+            }
+
+            foreach (var url in urls.Where(u => !string.IsNullOrWhiteSpace(u)).Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                var result = await DownloadCoverAsync(url);
+                if (result.data != null && result.data.Length > 0)
+                    return result;
             }
 
             return (null, null);
@@ -154,7 +175,10 @@ namespace OmniMixPlayer.Module.QQMusic
         {
             try
             {
-                var response = await _httpClient.GetAsync(url);
+                using var request = new HttpRequestMessage(HttpMethod.Get, QQMusicSongRegistry.NormalizeCoverUrl(url));
+                request.Headers.UserAgent.ParseAdd("Mozilla/5.0");
+                request.Headers.Referrer = new Uri("https://y.qq.com/");
+                using var response = await _httpClient.SendAsync(request);
                 if (response.IsSuccessStatusCode)
                 {
                     var data = await response.Content.ReadAsByteArrayAsync();

--- a/OmniMixPlayer/modules/QQMusic/QQMusicCoverLoader.cs
+++ b/OmniMixPlayer/modules/QQMusic/QQMusicCoverLoader.cs
@@ -81,11 +81,6 @@ namespace OmniMixPlayer.Module.QQMusic
                 return (_defaultQQMusicCoverBytes, "image/png");
             }
 
-            if (string.IsNullOrEmpty(songInfo.CoverUrl))
-            {
-                return (_defaultQQMusicCoverBytes, "image/png");
-            }
-
             var result = await DownloadSongCoverAsync(songInfo);
             if (result.data != null)
             {
@@ -107,8 +102,7 @@ namespace OmniMixPlayer.Module.QQMusic
             {
                 var songInfo = _songInfoMap.Values.FirstOrDefault(s =>
                     !string.IsNullOrWhiteSpace(s.AlbumMid) &&
-                    albumId == $"qqmusic_album_{s.AlbumMid}" &&
-                    !string.IsNullOrWhiteSpace(s.CoverUrl));
+                    albumId == $"qqmusic_album_{s.AlbumMid}");
                 if (songInfo != null)
                 {
                     var result = await DownloadSongCoverAsync(songInfo);
@@ -131,11 +125,6 @@ namespace OmniMixPlayer.Module.QQMusic
             }
 
             if (!_songInfoMap.TryGetValue(uuid, out var songInfo))
-            {
-                return (_defaultQQMusicCoverBytes, "image/png");
-            }
-
-            if (string.IsNullOrEmpty(songInfo.CoverUrl))
             {
                 return (_defaultQQMusicCoverBytes, "image/png");
             }

--- a/OmniMixPlayer/modules/QQMusic/QQMusicModule.cs
+++ b/OmniMixPlayer/modules/QQMusic/QQMusicModule.cs
@@ -207,7 +207,12 @@ namespace OmniMixPlayer.Module.QQMusic
                     return null;
                 }
 
-                var audioFormat = AudioFormatExtensions.FromExtension(songUrl.Format ?? InferFormatFromUrl(songUrl.URL));
+                var formatHint = string.IsNullOrWhiteSpace(songUrl.Format)
+                    ? InferFormatFromUrl(songUrl.URL)
+                    : songUrl.Format;
+                var audioFormat = AudioFormatExtensions.FromExtension(formatHint);
+                if (audioFormat == AudioFormat.Unknown)
+                    audioFormat = AudioFormat.Mp3;
                 var cachePath = Path.Combine(
                     Path.GetTempPath(),
                     "chillpatcher_audio_cache",

--- a/OmniMixPlayer/modules/QQMusic/QQMusicModule.cs
+++ b/OmniMixPlayer/modules/QQMusic/QQMusicModule.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
+using OmniMixPlayer.SDK;
 using OmniMixPlayer.SDK.Attributes;
 using OmniMixPlayer.SDK.Events;
 using OmniMixPlayer.SDK.Interfaces;
@@ -205,13 +207,13 @@ namespace OmniMixPlayer.Module.QQMusic
                     return null;
                 }
 
-                // Determine format
-                var format = !string.IsNullOrEmpty(songUrl.Format) ? songUrl.Format.ToLowerInvariant() : "mp3";
-                var audioFormat = string.Equals(format, "flac", StringComparison.OrdinalIgnoreCase)
-                    ? AudioFormat.Flac
-                    : AudioFormat.Mp3;
+                var audioFormat = AudioFormatExtensions.FromExtension(songUrl.Format ?? InferFormatFromUrl(songUrl.URL));
+                var cachePath = Path.Combine(
+                    Path.GetTempPath(),
+                    "chillpatcher_audio_cache",
+                    $"qqmusic_{songInfo.Mid}.{audioFormat.GetFileExtension()}");
 
-                _logger?.LogInformation($"Got URL for {songInfo.Name} [format={format}, size={songUrl.Size}] (attempt {attempt}/{maxRetries})");
+                _logger?.LogInformation($"Got URL for {songInfo.Name} [format={audioFormat.ToFormatString()}, size={songUrl.Size}] (attempt {attempt}/{maxRetries})");
 
                 return new PlayableSource
                 {
@@ -220,12 +222,19 @@ namespace OmniMixPlayer.Module.QQMusic
                     Url = songUrl.URL,
                     Format = audioFormat,
                     Headers = new Dictionary<string, string> { ["User-Agent"] = "Mozilla/5.0" },
-                    CacheKey = $"qqmusic_{songInfo.Mid}"
+                    CachePath = cachePath,
+                    UseCachePath = true
                 };
             }
 
             return null;
         }
+
+        private static string InferFormatFromUrl(string url)
+        {
+            return AudioFormatExtensions.InferFormatFromPath(url) ?? "mp3";
+        }
+
 
         public Task<PlayableSource> RefreshUrlAsync(
             string uuid,
@@ -448,8 +457,9 @@ namespace OmniMixPlayer.Module.QQMusic
 
                 _logger?.LogInformation($"Registered {registeredFavorites.Count} favorite songs");
 
-                // Import custom playlists
-                await ImportCustomPlaylistsAsync();
+                // Import the user's original QQ Music playlist structure, then
+                // append any manually configured playlist IDs.
+                await ImportPlaylistsAsync();
                 _logger?.LogInformation("ScanAndRegisterAsync: Completed");
             }
             catch (Exception ex)
@@ -485,36 +495,86 @@ namespace OmniMixPlayer.Module.QQMusic
             }
         }
 
-        private async Task ImportCustomPlaylistsAsync()
+        private async Task ImportPlaylistsAsync()
         {
-            var playlistIdsStr = _context.ConfigManager.GetValue<string>("CustomPlaylistIds", "");
-            if (string.IsNullOrWhiteSpace(playlistIdsStr)) return;
+            var playlists = new List<QQMusicBridge.PlaylistInfo>();
+            var seenPlaylistIds = new HashSet<long>();
+            var loadedUserPlaylists = false;
 
-            var ids = playlistIdsStr.Split(',')
-                .Select(s => s.Trim())
-                .Where(s => long.TryParse(s, out _))
-                .Select(long.Parse)
-                .ToList();
-
-            foreach (var playlistId in ids)
+            try
             {
-                try
+                var userPlaylists = await Task.Run(() => _bridge.GetUserPlaylists());
+                loadedUserPlaylists = userPlaylists != null;
+                foreach (var playlist in (userPlaylists?.Created ?? new List<QQMusicBridge.PlaylistInfo>())
+                    .Concat(userPlaylists?.Collected ?? new List<QQMusicBridge.PlaylistInfo>()))
                 {
-                    var detail = await Task.Run(() => _bridge.GetPlaylistSongs(playlistId));
-                    if (detail == null || detail.Songs == null) continue;
-
-                    _songRegistry.RegisterPlaylist(playlistId, detail.DissName, detail.CoverUrl);
-
-                    var musicList = _songRegistry.RegisterPlaylistSongs(playlistId, detail.Songs, _songInfoMap);
-                    _customPlaylistMusicLists[playlistId] = musicList;
-
-                    _logger?.LogInformation($"Imported playlist: {detail.DissName} ({musicList.Count} songs)");
-                }
-                catch (Exception ex)
-                {
-                    _logger?.LogError($"Failed to import playlist {playlistId}: {ex.Message}");
+                    if (playlist != null && playlist.DissID > 0 && seenPlaylistIds.Add(playlist.DissID))
+                        playlists.Add(playlist);
                 }
             }
+            catch (Exception ex)
+            {
+                _logger?.LogError($"Failed to get QQ Music user playlists: {ex.Message}");
+            }
+
+            var playlistIdsStr = _context.ConfigManager.GetValue<string>("CustomPlaylistIds", "");
+            if (!string.IsNullOrWhiteSpace(playlistIdsStr))
+            {
+                foreach (var playlistId in playlistIdsStr.Split(',')
+                    .Select(s => s.Trim())
+                    .Where(s => long.TryParse(s, out _))
+                    .Select(long.Parse))
+                {
+                    if (playlistId > 0 && seenPlaylistIds.Add(playlistId))
+                        playlists.Add(new QQMusicBridge.PlaylistInfo { DissID = playlistId });
+                }
+            }
+
+            foreach (var playlist in playlists)
+                await ImportPlaylistAsync(playlist);
+
+            if (loadedUserPlaylists)
+            {
+                var stalePlaylists = _context.Library.QueryPlaylists(new PlaylistQuery
+                {
+                    ModuleId = ModuleId,
+                    Limit = 0
+                }).Where(p => p.Id.StartsWith("qqmusic_playlist_", StringComparison.Ordinal) &&
+                             !seenPlaylistIds.Contains(ParsePlaylistId(p.Id))).ToList();
+                foreach (var stalePlaylist in stalePlaylists)
+                    _context.Library.DeletePlaylist(stalePlaylist.Id);
+            }
+        }
+
+        private async Task ImportPlaylistAsync(QQMusicBridge.PlaylistInfo playlist)
+        {
+            try
+            {
+                var detail = await Task.Run(() => _bridge.GetPlaylistSongs(playlist.DissID));
+                if (detail?.Songs == null) return;
+
+                var name = !string.IsNullOrWhiteSpace(detail.DissName) ? detail.DissName : playlist.DissName;
+                var coverUrl = !string.IsNullOrWhiteSpace(detail.CoverUrl) ? detail.CoverUrl : playlist.CoverUrl;
+                _songRegistry.RegisterPlaylist(playlist.DissID, name, coverUrl);
+
+                var musicList = _songRegistry.RegisterPlaylistSongs(playlist.DissID, detail.Songs, _songInfoMap);
+                _customPlaylistMusicLists[playlist.DissID] = musicList;
+                _logger?.LogInformation($"Imported playlist: {name} ({musicList.Count} songs)");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError($"Failed to import playlist {playlist.DissID}: {ex.Message}");
+            }
+        }
+
+        private static long ParsePlaylistId(string playlistId)
+        {
+            const string prefix = "qqmusic_playlist_";
+            return playlistId != null &&
+                   playlistId.StartsWith(prefix, StringComparison.Ordinal) &&
+                   long.TryParse(playlistId.Substring(prefix.Length), out var parsed)
+                ? parsed
+                : 0;
         }
 
         private void OnFavoriteChanged(FavoriteChangedEvent evt)

--- a/OmniMixPlayer/modules/QQMusic/QQMusicSongRegistry.cs
+++ b/OmniMixPlayer/modules/QQMusic/QQMusicSongRegistry.cs
@@ -57,7 +57,7 @@ namespace OmniMixPlayer.Module.QQMusic
                 Name = name,
                 ModuleId = _moduleId,
                 Kind = PlaylistKind.Imported,
-                CoverUri = coverUrl ?? ""
+                CoverUri = NormalizeCoverUrl(coverUrl)
             });
         }
 
@@ -158,7 +158,7 @@ namespace OmniMixPlayer.Module.QQMusic
                 track.SourcePath = song.Mid;
                 track.ModuleId = _moduleId;
                 track.IsFavorite = false;
-                track.CoverUri = song.CoverUrl ?? "";
+                track.CoverUri = NormalizeCoverUrl(song.CoverUrl);
 
                 _context.Library.UpsertTrack(track);
                 tracks.Add(track);
@@ -220,7 +220,7 @@ namespace OmniMixPlayer.Module.QQMusic
             track.SourcePath = song.Mid;
             track.ModuleId = _moduleId;
             track.IsFavorite = isFavorite;
-            track.CoverUri = song.CoverUrl ?? "";
+            track.CoverUri = NormalizeCoverUrl(song.CoverUrl);
 
             _context.Library.UpsertTrack(track);
             return track;
@@ -261,9 +261,21 @@ namespace OmniMixPlayer.Module.QQMusic
                 Title = song.Album ?? "",
                 Artist = song.ArtistString,
                 ModuleId = _moduleId,
-                CoverUri = song.CoverUrl ?? ""
+                CoverUri = NormalizeCoverUrl(song.CoverUrl)
             });
             return albumId;
+        }
+
+        public static string NormalizeCoverUrl(string coverUrl)
+        {
+            if (string.IsNullOrWhiteSpace(coverUrl)) return "";
+
+            var normalized = coverUrl.Trim();
+            if (normalized.StartsWith("//", StringComparison.Ordinal))
+                return "https:" + normalized;
+            if (normalized.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+                return "https://" + normalized.Substring("http://".Length);
+            return normalized;
         }
 
         #endregion


### PR DESCRIPTION
## 摘要

尝试修复 QQ 音乐不正常跳歌的问题。

主要改动：

- QQ 音乐播放源不再把除 FLAC 外的所有格式都当成 MP3，而是优先使用桥接层返回的格式，并在缺失时从 URL 推断格式。
- QQ 音乐缓存路径改为带真实音频扩展名，避免 M4A/AAC 链接被缓存成无扩展名或错误格式后影响解码。
- 对 AAC/M4A/MP4 这类不适合边下载边解析的容器，流式读取器不再在缓存未完成时提前打开 decoder；缓存完成后以非 growing 文件方式重新打开，并保留当前播放帧。
- 在 SDK 层增加统一的音频格式工具方法，用于格式字符串、文件扩展名、URL/path 推断和渐进式解码支持判断。
- QQ 音乐用户歌单接口增加旧 FCG profile 接口兜底，避免新版 musicu CGI 拒绝请求时无法导入用户创建/收藏歌单。
- QQ 音乐封面地址统一规范化为 HTTPS，并增加基于 album mid 的封面兜底地址。
- 网易云模块同步使用统一音频格式映射，减少模块间格式处理差异。

## 测试

- dotnet build "OmniMixPlayer/OmniMixPlayer.sln" -c Debug -v minimal --no-restore

本地构建通过，仅有既有 analyzer/package warning。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QQ Music integration now imports your personal created and collected playlists automatically.
  * Added progressive decoding support for improved streaming performance.

* **Bug Fixes**
  * Enhanced playlist fetching with fallback mechanisms for better reliability.
  * Improved cover URL handling with automatic HTTPS normalization.
  * Fixed audio format detection and caching behavior.

* **Improvements**
  * Optimized decoder initialization for better resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->